### PR TITLE
Move typescript-memoize to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "registry-url": "4.0.0",
     "semver": "^5.6.0",
     "signale": "^1.3.0",
+    "typescript-memoize": "^1.0.0-alpha.3",
     "url-join": "^4.0.0"
   },
   "devDependencies": {
@@ -58,7 +59,6 @@
     "tslint-config-prettier": "~1.17.0",
     "tslint-xo": "~0.10.0",
     "typescript": "~3.2.1",
-    "typescript-memoize": "^1.0.0-alpha.3",
     "typescript-tslint-plugin": "^0.1.2"
   },
   "prettier": {


### PR DESCRIPTION
`devDeps` don't get shipped to consumer packages
