### PR TITLE
Add git user options

### DIFF
--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -10,8 +10,8 @@ Prepend release notes to `CHANGELOG.md`, create one if it doesn't exist, and com
 >  auto changelog -h
 
 usage: auto changelog [-h] [--from FROM] [--to TO] [--jira JIRA]
-                           [--no-version-prefix] [-d] [-m MESSAGE] [-v] [-vv]
-                           [--githubApi GITHUBAPI]
+                         [--no-version-prefix] [-d] [-m MESSAGE] [-v] [-vv]
+                         [--githubApi GITHUBAPI] [--name NAME] [--email EMAIL]
 
 
 Optional arguments:
@@ -30,6 +30,9 @@ Optional arguments:
   -vv, --very-verbose   Show a lot more logs
   --githubApi GITHUBAPI
                         Github API to use
+  --name NAME           Git name to commit and release with. Defaults to
+                        package.json
+  --email EMAIL         Git email to commit with. Defaults to package.json
 ```
 
 ## Jira

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -27,8 +27,8 @@ You will need to push the tags to github first:
 >  auto release -h
 
 usage: auto release [-h] [-s SLACK] [--use-version USE_VERSION]
-                         [--jira JIRA] [--no-version-prefix] [-d] [-v] [-vv]
-                         [--githubApi GITHUBAPI]
+                       [--jira JIRA] [--no-version-prefix] [-d] [-v] [-vv]
+                       [--githubApi GITHUBAPI] [--name NAME] [--email EMAIL]
 
 
 Optional arguments:
@@ -47,6 +47,9 @@ Optional arguments:
   -vv, --very-verbose   Show a lot more logs
   --githubApi GITHUBAPI
                         Github API to use
+  --name NAME           Git name to commit and release with. Defaults to
+                        package.json
+  --email EMAIL         Git email to commit with. Defaults to package.json
 ```
 
 ## Slack URL

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -93,3 +93,23 @@ If you are using enterprise github `auto-release` lets you configure the github 
   "jira": "https://url-to-jira.com"
 }
 ```
+
+### name
+
+Git name to commit and release with. Defaults to package.json. Used in `auto changelog` and `auto release`
+
+```json
+{
+  "name": "Joe Schmo"
+}
+```
+
+### email
+
+Git email to commit and release with. Defaults to package.json. Used in `auto changelog` and `auto release`
+
+```json
+{
+  "email": "joe@schmo.com"
+}
+```

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint": "tslint -p . --format stylish",
     "precommit": "lint-staged",
     "test": "jest",
-    "release": "./scripts/release.sh",
+    "release": "chmod +x ./dist/bin/auto.js && ./dist/bin/auto.js shipit",
     "contributors:add": "all-contributors",
     "contributors:generate": "all-contributors generate",
     "docs": "ignite",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,0 @@
-git config --global user.email "lisowski54@gmail.com"
-git config --global user.name "Andrew Lisowski"
-
-chmod +x ./dist/bin/auto.js
-export PATH=$(npm bin):$PATH
-
-./dist/bin/auto.js shipit

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -103,6 +103,16 @@ function addSemverParser(parser: ArgumentParser) {
   });
 }
 
+function addGitUser(parser: ArgumentParser) {
+  parser.addArgument(['--name'], {
+    help: 'Git name to commit and release with. Defaults to package.json'
+  });
+
+  parser.addArgument(['--email'], {
+    help: 'Git email to commit with. Defaults to package.json'
+  });
+}
+
 // All of the parsers for each command are setup in their own functions
 // This allows us to either use separate commands for each one (github-pr, github-label)
 // or group them under a single root command (github pr, github label)
@@ -170,6 +180,7 @@ export function addReleaseParser(parser: ArgumentParser) {
   addDryRun(parser);
 
   addLoggingParser(parser);
+  addGitUser(parser);
 }
 
 export function addVersionParser(parser: ArgumentParser) {
@@ -195,6 +206,7 @@ export function addChangelogParser(parser: ArgumentParser) {
   );
 
   addLoggingParser(parser);
+  addGitUser(parser);
 }
 
 export function addCommentParser(parser: ArgumentParser) {
@@ -245,6 +257,11 @@ export interface ISemverArgs {
   githubApi?: string;
 }
 
+export interface IOwnerArgs {
+  name?: string;
+  email?: string;
+}
+
 export interface IRepoArgs {
   owner?: string;
   repo?: string;
@@ -290,7 +307,8 @@ export type ArgsType = {
   IReleaseArgs &
   ICommentArgs &
   IPRArgs &
-  ILogArgs;
+  ILogArgs &
+  IOwnerArgs;
 
 export default function parse(stuff?: string[]): ArgsType {
   return rootParser.parseArgs(stuff);

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -45,6 +45,8 @@ export interface IGithubReleaseOptions {
   jira?: string;
   slack?: string;
   githubApi?: string;
+  name?: string;
+  email?: string;
   changelogTitles?: {
     [label: string]: string;
   };

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,27 @@ async function getCurrentVersion(
   return lastVersion;
 }
 
+async function setGitUser(args: IGithubReleaseOptions) {
+  const packageJson = JSON.parse(await readFile('package.json', 'utf-8'));
+  let { name, email } = args;
+
+  if (!name) {
+    ({ name } = packageJson.author);
+  }
+
+  if (!email) {
+    ({ email } = packageJson.author);
+  }
+
+  if (email) {
+    await execPromise(`git config user.email "${email}"`);
+  }
+
+  if (name) {
+    await execPromise(`git config user.name "${name}"`);
+  }
+}
+
 async function getVersion(githubRelease: GithubRelease, args: ArgsType) {
   const lastRelease = await githubRelease.getLatestRelease();
 
@@ -199,6 +220,8 @@ export async function run(args: ArgsType) {
     ...args,
     logger
   };
+
+  await setGitUser(config);
 
   let semVerLabels = defaultLabels;
 


### PR DESCRIPTION
# What Changed

Get git user from cli args, config, or package.json.

# Why

Previously `auto` would fail when no git user was set. 

closes #34

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
