### PR TITLE
Fix Single new project

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -218,14 +218,18 @@ describe('GithubRelease', () => {
   describe('addToChangelog', async () => {
     test("creates new changelog if one didn't exist", async () => {
       const gh = new GithubRelease();
-      await gh.addToChangelog('# My new Notes', 'v0.0.0');
+      await gh.addToChangelog(
+        '# My new Notes',
+        'klajsdlfk4lj51l43k5hj234l',
+        'v0.0.0'
+      );
 
       expect(writeSpy.mock.calls[0][1].includes(`# My new Notes`)).toBe(true);
     });
 
     test("creates new changelog if one didn't exist", async () => {
       const gh = new GithubRelease();
-      await gh.addToChangelog('# My new Notes', 'v1.0.0', false);
+      await gh.addToChangelog('# My new Notes', 'v1.0.0', 'v1.0.0', false);
 
       expect(writeSpy.mock.calls[0][1].includes(`v1.0.1`)).toBe(true);
     });
@@ -236,7 +240,11 @@ describe('GithubRelease', () => {
       existsSync.mockReturnValueOnce(true);
       readResult = '# My old Notes';
 
-      await gh.addToChangelog('# My new Notes', 'v0.0.0');
+      await gh.addToChangelog(
+        '# My new Notes',
+        'asdfasdlkfjlkj435l2j',
+        'v0.0.0'
+      );
       expect(writeSpy.mock.calls[0][1].includes(readResult)).toBe(true);
     });
 
@@ -247,7 +255,13 @@ describe('GithubRelease', () => {
       existsSync.mockReturnValueOnce(true);
       readResult = '# My old Notes';
 
-      await gh.addToChangelog('# My new Notes', 'v0.0.0', false, message);
+      await gh.addToChangelog(
+        '# My new Notes',
+        'asdklfhlkh24387513',
+        'v0.0.0',
+        false,
+        message
+      );
       expect(execSpy.mock.calls[1][0].includes(message)).toBe(true);
     });
   });

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -159,17 +159,28 @@ export default class GithubRelease {
   public async addToChangelog(
     releaseNotes: string,
     lastRelease: string,
+    currentVersion: string,
     noVersionPrefix = true,
     message = 'Update CHANGELOG.md [skip ci]'
   ) {
     this.logger.verbose.info('Adding new changes to changelog.');
 
-    const version = await this.calcNextVersion(lastRelease);
+    let version;
+
+    if (lastRelease.match(/\d+\.\d+\.\d+/)) {
+      version = await this.calcNextVersion(lastRelease);
+    } else {
+      const bump = await this.getSemverBump(lastRelease);
+      version = inc(currentVersion, bump as ReleaseType);
+    }
 
     this.logger.verbose.info('Calculated next version to be:', version);
 
     const date = new Date().toDateString();
-    const prefixed = noVersionPrefix ? version : `v${version}`;
+    const prefixed =
+      noVersionPrefix || (version && version.includes('v'))
+        ? version
+        : `v${version}`;
 
     let newChangelog = `# ${prefixed} (${date})\n\n${releaseNotes}`;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,6 +134,7 @@ async function makeChangelog(
 
     await githubRelease.addToChangelog(
       releaseNotes,
+      lastRelease,
       currentVersion,
       args.no_version_prefix,
       args.message || undefined


### PR DESCRIPTION
# What Changed

If last release is a commit sha, calc bump using SHA and bump current calculated version (most likely from package.json).

# Why

When in a new project with no releases but with a version in package.json

1. Get latest release, it's a SHA
2. `getCurrentVersion` defaults to package.json version when it doesn't find a suitable tag
3. the `currentVersion` (unpublished) made it way to changelog creation. Where it uses the last release as the `from` in `auto changelog`
4. Since that version only exists in the package.json, git log creation would fail

now we check if the last release looks like a version number, and if it doesn't use the first commit to calculate a version bump and then bump the `currentVersion` with it.

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add SemVer label
