### PR TITLE
Allow user to configure multiple labels to `no-release`

### DIFF
--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -5,13 +5,17 @@ Get the semantic version bump for the given changes. Requires all PRs to have la
 ```bash
 >  auto version -h
 
-usage: auto version [-h] [--onlyPublishWithReleaseLabel] [--major MAJOR]
-                         [--minor MINOR] [--patch PATCH] [-v] [-vv]
-                         [--githubApi GITHUBAPI]
+usage: auto.js version [-h] [--noReleaseLabels NORELEASELABELS]
+                       [--onlyPublishWithReleaseLabel] [--major MAJOR]
+                       [--minor MINOR] [--patch PATCH] [-v] [-vv]
+                       [--githubApi GITHUBAPI]
 
 
 Optional arguments:
   -h, --help            Show this help message and exit.
+  --noReleaseLabels NORELEASELABELS
+                        Labels that will not create a release. Defaults to
+                        just 'no-release'
   --onlyPublishWithReleaseLabel
                         Only bump version if `release` label is on pull
                         request

--- a/package.json
+++ b/package.json
@@ -128,5 +128,10 @@
     "githubURL": "https://github.com/intuit/auto-release",
     "customHead": "<style>.content p > .header-image { max-width: 200px !important; } .navbar { box-shadow: none !important; border-bottom: 1px solid lightgrey; } .list { font-size: 1.2rem; } .is-purple { background: #870048 !important;  } .has-text-purple { color: #870048 !important;  } .is-red { background: #C5000B !important;  } .is-yellow { background: #F1A60E !important;  } a.navbar-item.is-active, a.navbar-item:hover, a.navbar-link.is-active, a.navbar-link:hover { background-color: #f5f5f5;color: #870048; } .button.is-link.is-inverted.is-outlined:hover { background-color: #fff;color: #870048; } p .image { max-width: 100% !important; }.menu .menu-list a.is-active {background-color: transparent;color: #870048;}</style>",
     "favicon": "favicon.png"
+  },
+  "auto": {
+    "noReleaseLabels": [
+      "documentation"
+    ]
   }
 }

--- a/src/__tests__/semver.test.ts
+++ b/src/__tests__/semver.test.ts
@@ -19,4 +19,24 @@ describe('calculateSemVerBump', () => {
       SEMVER.premajor
     );
   });
+
+  test('should be able to use multiple labels for no-release', () => {
+    expect(
+      calculateSemVerBump([['no-release', 'major']], defaultLabels, {
+        noReleaseLabels: ['documentation']
+      })
+    ).toBe(SEMVER.noVersion);
+
+    expect(
+      calculateSemVerBump([['documentation', 'major']], defaultLabels, {
+        noReleaseLabels: ['documentation']
+      })
+    ).toBe(SEMVER.noVersion);
+
+    expect(
+      calculateSemVerBump([['major']], defaultLabels, {
+        noReleaseLabels: ['documentation']
+      })
+    ).toBe(SEMVER.major);
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -190,6 +190,12 @@ export function addReleaseParser(parser: ArgumentParser) {
 }
 
 export function addVersionParser(parser: ArgumentParser) {
+  parser.addArgument(['--noReleaseLabels'], {
+    help:
+      "Labels that will not create a release. Defaults to just 'no-release'",
+    type: Array
+  });
+
   addSemverParser(parser);
   addLoggingParser(parser);
 }
@@ -256,6 +262,7 @@ PARSERS.forEach(([parserName, parserFunction]) => {
 });
 
 export interface ISemverArgs {
+  noReleaseLabels?: string[];
   onlyPublishWithReleaseLabel?: boolean;
   major?: string;
   minor?: string;

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -335,11 +335,12 @@ export default class GithubRelease {
   public async getSemverBump(
     from: string,
     to = 'HEAD',
-    onlyPublishWithReleaseLabel = false
+    onlyPublishWithReleaseLabel = false,
+    noReleaseLabels: string[] = []
   ): Promise<SEMVER> {
     const commits = await this.getCommits(from, to);
     const labels = commits.map(commit => commit.labels);
-    const options = { onlyPublishWithReleaseLabel };
+    const options = { onlyPublishWithReleaseLabel, noReleaseLabels };
     const versionLabels = new Map([...defaultLabels, ...this.userLabels]);
 
     this.logger.verbose.info('Calculating SEMVER bump using:\n', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,8 @@ async function getVersion(githubRelease: GithubRelease, args: ArgsType) {
   return githubRelease.getSemverBump(
     lastRelease,
     undefined,
-    args.onlyPublishWithReleaseLabel
+    args.onlyPublishWithReleaseLabel,
+    args.noReleaseLabels
   );
 }
 

--- a/src/semver.ts
+++ b/src/semver.ts
@@ -28,14 +28,19 @@ export function getHigherSemverTag(left: string, right: string): SEMVER {
 
 interface ISemVerOptions {
   onlyPublishWithReleaseLabel?: boolean;
+  noReleaseLabels?: string[];
 }
 
 export function calculateSemVerBump(
   labels: string[][],
   labelMap: IVersionLabels,
-  { onlyPublishWithReleaseLabel }: ISemVerOptions = {}
+  { onlyPublishWithReleaseLabel, noReleaseLabels = [] }: ISemVerOptions = {}
 ) {
   const labelSet = new Set<string>();
+
+  if (!noReleaseLabels.includes(labelMap.get('no-release')!)) {
+    noReleaseLabels.push(labelMap.get('no-release')!);
+  }
 
   labels.map(pr =>
     pr.forEach(label => {
@@ -51,7 +56,7 @@ export function calculateSemVerBump(
     isPrerelease = labels[0].includes(labelMap.get('prerelease')!);
     noRelease = onlyPublishWithReleaseLabel
       ? !labels[0].includes(labelMap.get('release')!)
-      : labels[0].includes(labelMap.get('no-release')!);
+      : !!labels[0].find(label => noReleaseLabels.includes(label));
   }
 
   const version = [...labelSet].reduce(


### PR DESCRIPTION
# What Changed

User now has the option to specify more labels that will not generate a release. It will always include the configured `no-release` label as a default.

# Why

I wanted specific labels to always not generate a release. 

Todo:

- [x] Add tests
- [x] Add docs
- [x] Add SemVer label
