### PR TITLE
rename init-labels -> create-labels

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
 
 - [Setup](pages/auto-init.md)
   - [auto init](pages/auto-init.md#auto-init)
-  - [auto init-labels](pages/auto-init.md#auto-init-labels)
+  - [auto create-labels](pages/auto-init.md#auto-create-labels)
 - [Publishing](pages/publishing.md)
   - [auto version](pages/auto-version.md)
   - [auto changelog](pages/auto-changelog.md)

--- a/docs/pages/auto-init.md
+++ b/docs/pages/auto-init.md
@@ -14,12 +14,12 @@ Examples
   $ auto init
 ```
 
-## `auto init-labels`
+## `auto create-labels`
 
 Create your projects labels on github.
 
 ```sh
-$ auto init-labels --help
+$ auto create-labels --help
 
 Global Options
 
@@ -32,9 +32,9 @@ Global Options
 
 Examples
 
-  $ auto init-labels
+  $ auto create-labels
 ```
 
 ::: message is-warning
-:warning: For this to work you must have a `GH_TOKEN` set, ex: `GH_TOKEN=YOUR_TOKEN auto init-labels`
+:warning: For this to work you must have a `GH_TOKEN` set, ex: `GH_TOKEN=YOUR_TOKEN auto create-labels`
 :::

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -15,7 +15,7 @@ If you are using enterprise github `auto-release` lets you configure the github 
 Getting started with `auto-release` is super easy.
 
 1. `auto init` (optional)
-2. `auto init-labels`
+2. `auto create-labels`
 3. Configure environment variables
 4. Set up script
 
@@ -33,7 +33,7 @@ After that, you need to set up the labels on your github project. The types of l
 To create the labels for your project on Github, run the following command with your `GH_TOKEN`.
 
 ```sh
-GH_TOKEN=YOUR_TOKEN auto init-labels
+GH_TOKEN=YOUR_TOKEN auto create-labels
 ```
 
 ### 3. Environment Variables

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -189,9 +189,9 @@ const commands: ICommand[] = [
     examples: ['{green $} auto init']
   },
   {
-    name: 'init-labels',
+    name: 'create-labels',
     summary: 'Create your projects labels on github.',
-    examples: ['{green $} auto init-labels'],
+    examples: ['{green $} auto create-labels'],
     options: defaultOptions
   },
   {
@@ -395,7 +395,7 @@ function printRootHelp() {
     {
       header: 'Setup Commands',
       content: commands
-        .filter(command => ['init', 'init-labels'].includes(command.name))
+        .filter(command => ['init', 'create-labels'].includes(command.name))
         .map(command => ({
           name: command.name,
           summary: command.summary

--- a/src/main.ts
+++ b/src/main.ts
@@ -250,7 +250,7 @@ export async function run(args: ArgsType) {
       await init();
       break;
     }
-    case 'init-labels': {
+    case 'create-labels': {
       await githubRelease.addLabelsToProject(
         semVerLabels,
         args.onlyPublishWithReleaseLabel


### PR DESCRIPTION
# What Changed

rename init-labels -> create-labels

# Why

it makes more sense this way and i'm also gonna add a flag to init to --labels to just init the albels

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label (this would be breaking but it's under 1.0 so we can skip that)
