### PR TITLE
init flag to just get labels

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -35,6 +35,7 @@ const mainDefinitions: commandLineUsage.OptionDefinition[] = [
     description: 'Display the help output. Works on each command as well'
   }
 ];
+
 const defaultOptions = [
   {
     ...help,
@@ -181,7 +182,16 @@ const commands: ICommand[] = [
   {
     name: 'init',
     summary: 'Interactive setup for most configurable options',
-    examples: ['{green $} auto init']
+    examples: ['{green $} auto init'],
+    options: [
+      {
+        name: 'only-labels',
+        type: Boolean,
+        group: 'main',
+        description:
+          'Only run init for the labels. As most other options are for advanced users'
+      }
+    ]
   },
   {
     name: 'create-labels',
@@ -449,11 +459,17 @@ function printCommandHelp(command: ICommand) {
       });
     }
 
-    sections.push({
-      header: 'Global Options',
-      optionList: command.options,
-      group: 'misc'
-    });
+    const hasGlobalOptions = command.options.filter(
+      option => option.group === 'misc'
+    );
+
+    if (hasGlobalOptions.length > 0) {
+      sections.push({
+        header: 'Global Options',
+        optionList: command.options,
+        group: 'misc'
+      });
+    }
   }
 
   sections.push({
@@ -527,6 +543,7 @@ export default function parseArgs(testArgs?: string[]) {
     process.exit(0);
   }
 
+  console.log(autoOptions);
   return autoOptions;
 }
 
@@ -578,6 +595,10 @@ export interface ICommentArgs {
   message?: string;
 }
 
+export interface IInitArgs {
+  'only-labels'?: boolean;
+}
+
 export interface ILogArgs {
   verbose?: boolean;
   very_verbose?: boolean;
@@ -592,4 +613,5 @@ export type ArgsType = {
   ICommentArgs &
   IPRArgs &
   ILogArgs &
-  IOwnerArgs;
+  IOwnerArgs &
+  IInitArgs;

--- a/src/init.ts
+++ b/src/init.ts
@@ -187,8 +187,8 @@ documentation: #{documentation}
   return changelogTitles;
 }
 
-export default async function init() {
-  const flags = await getFlags();
+export default async function init(onlyLabels?: boolean) {
+  const flags = onlyLabels ? {} : await getFlags();
   const labels = await getLabels();
   const changelogTitles = await getChangelogTitles();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -247,7 +247,7 @@ export async function run(args: ArgsType) {
 
   switch (args.command) {
     case 'init': {
-      await init();
+      await init(args['only-labels']);
       break;
     }
     case 'create-labels': {


### PR DESCRIPTION
# What Changed

- add flag for init to just get labels
- omit global option in help dialog if not exist for the command

# Why

closes #72

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
