### PR TITLE
Configure changelog labels with create-labels

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -538,7 +538,6 @@ export default function parseArgs(testArgs?: string[]) {
     process.exit(0);
   }
 
-  console.log(autoOptions);
   return autoOptions;
 }
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -380,6 +380,15 @@ const commands: ICommand[] = [
   }
 ];
 
+function filterCommands(allCommands: ICommand[], include: string[]) {
+  return allCommands
+    .filter(command => include.includes(command.name))
+    .map(command => ({
+      name: command.name,
+      summary: command.summary
+    }));
+}
+
 function printRootHelp() {
   const options = [...mainDefinitions, ...defaultOptions];
   options.forEach(option => styleTypes({} as ICommand, option));
@@ -399,34 +408,20 @@ function printRootHelp() {
     },
     {
       header: 'Setup Commands',
-      content: commands
-        .filter(command => ['init', 'create-labels'].includes(command.name))
-        .map(command => ({
-          name: command.name,
-          summary: command.summary
-        }))
+      content: filterCommands(commands, ['init', 'create-labels'])
     },
     {
       header: 'Release Commands',
-      content: commands
-        .filter(command =>
-          ['release', 'version', 'changelog', 'shipit'].includes(command.name)
-        )
-        .map(command => ({
-          name: command.name,
-          summary: command.summary
-        }))
+      content: filterCommands(commands, [
+        'release',
+        'version',
+        'changelog',
+        'shipit'
+      ])
     },
     {
       header: 'Pull Request Interaction Commands',
-      content: commands
-        .filter(command =>
-          ['label', 'pr-check', 'pr', 'comment'].includes(command.name)
-        )
-        .map(command => ({
-          name: command.name,
-          summary: command.summary
-        }))
+      content: filterCommands(commands, ['label', 'pr-check', 'pr', 'comment'])
     },
     {
       header: 'Global Options',

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,11 +2,7 @@ import GHub from '@octokit/rest';
 import { ICommit, parseGit } from 'parse-git';
 import { Memoize } from 'typescript-memoize';
 
-import {
-  defaultLabelsDescriptions,
-  ILogger,
-  VersionLabel
-} from './github-release';
+import { defaultLabelsDescriptions, ILogger } from './github-release';
 import execPromise from './utils/exec-promise';
 
 export interface IGithubOptions {
@@ -247,7 +243,7 @@ export default class Github {
     return result;
   }
 
-  public async createLabel(label: VersionLabel, name: string) {
+  public async createLabel(label: string, name: string) {
     await this.authenticate();
 
     this.logger.verbose.info(`Creating "${label}" label :\n${name}`);

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -40,7 +40,7 @@ export const defaultChangelogTitles = {
   documentation: '📝  Documentation'
 };
 
-export const defaultLabelsDescriptions = new Map<VersionLabel, string>();
+export const defaultLabelsDescriptions = new Map<string, string>();
 defaultLabelsDescriptions.set(SEMVER.major, 'create a major release');
 defaultLabelsDescriptions.set(SEMVER.minor, 'create a minor release');
 defaultLabelsDescriptions.set(SEMVER.patch, 'create a patch release');
@@ -50,6 +50,14 @@ defaultLabelsDescriptions.set(
   'publish a release when this pr is merged'
 );
 defaultLabelsDescriptions.set('prerelease', 'create pre release');
+defaultLabelsDescriptions.set(
+  'internal',
+  'changes are internal to the project'
+);
+defaultLabelsDescriptions.set(
+  'documentation',
+  'changes only effect documentation'
+);
 
 export interface ILogger {
   log: signale.Signale<signale.DefaultMethods>;
@@ -307,7 +315,7 @@ export default class GithubRelease {
   }
 
   public async addLabelsToProject(
-    labels: Map<VersionLabel, string>,
+    labels: Map<string, string>,
     onlyPublishWithReleaseLabel?: boolean
   ) {
     const client = await this.github;

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { promisify } from 'util';
 import { ArgsType } from './cli/args';
 import { IPRInfo } from './git';
 import GithubRelease, {
+  defaultChangelogTitles,
   defaultLabels,
   IGithubReleaseOptions
 } from './github-release';
@@ -252,7 +253,14 @@ export async function run(args: ArgsType) {
     }
     case 'create-labels': {
       await githubRelease.addLabelsToProject(
-        semVerLabels,
+        new Map([
+          ...semVerLabels,
+          ...new Map(
+            Object.keys(defaultChangelogTitles).map(
+              (label): [string, string] => [label, label]
+            )
+          )
+        ]),
         args.onlyPublishWithReleaseLabel
       );
       break;

--- a/src/main.ts
+++ b/src/main.ts
@@ -256,9 +256,10 @@ export async function run(args: ArgsType) {
         new Map([
           ...semVerLabels,
           ...new Map(
-            Object.keys(defaultChangelogTitles).map(
-              (label): [string, string] => [label, label]
-            )
+            [
+              ...Object.keys(defaultChangelogTitles),
+              ...Object.keys(config.changelogTitles || {})
+            ].map((label): [string, string] => [label, label])
           )
         ]),
         args.onlyPublishWithReleaseLabel


### PR DESCRIPTION
# What Changed

create-labels makes a Map of the changelog labels and version labels now

# Why

closes #66

Todo:

- [ ] Add tests
- [ ] Add docs
- [x] Add SemVer label
