### PR TITLE
missed adding no release labels to `pr-check`

### DIFF
--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -20,6 +20,7 @@ Options
   --minor string                   The name of the tag for a minor version bump
   --patch string                   The name of the tag for a patch version bump
   --context string                 A string label to differentiate this status from others
+  --noReleaseLabels string[]       Labels that will not create a release. Defaults to just 'no-release'
 
 Global Options
 

--- a/package.json
+++ b/package.json
@@ -132,10 +132,5 @@
     "githubURL": "https://github.com/intuit/auto-release",
     "customHead": "<style>.content p > .header-image { max-width: 200px !important; } .navbar { box-shadow: none !important; border-bottom: 1px solid lightgrey; } .list { font-size: 1.2rem; } .is-purple { background: #870048 !important;  } .has-text-purple { color: #870048 !important;  } .is-red { background: #C5000B !important;  } .is-yellow { background: #F1A60E !important;  } a.navbar-item.is-active, a.navbar-item:hover, a.navbar-link.is-active, a.navbar-link:hover { background-color: #f5f5f5;color: #870048; } .button.is-link.is-inverted.is-outlined:hover { background-color: #fff;color: #870048; } p .image { max-width: 100% !important; }.menu .menu-list a.is-active {background-color: transparent;color: #870048;}</style>",
     "favicon": "favicon.png"
-  },
-  "auto": {
-    "noReleaseLabels": [
-      "documentation"
-    ]
   }
 }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -170,6 +170,15 @@ const message: commandLineUsage.OptionDefinition = {
   alias: 'm'
 };
 
+const noReleaseLabels: commandLineUsage.OptionDefinition = {
+  name: 'noReleaseLabels',
+  type: String,
+  group: 'main',
+  multiple: true,
+  description:
+    "Labels that will not create a release. Defaults to just 'no-release'"
+};
+
 interface ICommand {
   name: string;
   summary: string;
@@ -220,6 +229,7 @@ const commands: ICommand[] = [
         ...context,
         defaultValue: 'ci/pr-check'
       },
+      noReleaseLabels,
       ...defaultOptions
     ],
     examples: [
@@ -268,18 +278,7 @@ const commands: ICommand[] = [
   {
     name: 'version',
     summary: 'Get the semantic version bump for the given changes.',
-    options: [
-      ...semver,
-      {
-        name: 'noReleaseLabels',
-        type: String,
-        group: 'main',
-        multiple: true,
-        description:
-          "Labels that will not create a release. Defaults to just 'no-release'"
-      },
-      ...defaultOptions
-    ],
+    options: [...semver, noReleaseLabels, ...defaultOptions],
     examples: [
       {
         desc: 'Get the new version using the last release to head',

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,9 +344,18 @@ export async function run(args: ArgsType) {
         const labels = await githubRelease.getLabels(args.pr!);
         const labelTexts = Object.values(semVerLabels);
         const releaseTag = labels.find(l => l === 'release');
-        const noReleaseTag = labels.find(l => l === 'no-release');
+        const noReleaseLabels = args.noReleaseLabels || [];
+
+        if (!noReleaseLabels.includes(semVerLabels.get('no-release')!)) {
+          noReleaseLabels.push(semVerLabels.get('no-release')!);
+        }
+
+        const noReleaseTag = labels.find(l => noReleaseLabels.includes(l));
         const semverTag = labels.find(
-          l => labelTexts.includes(l) && l !== 'no-release' && l !== 'release'
+          l =>
+            labelTexts.includes(l) &&
+            !noReleaseLabels.includes(l) &&
+            l !== 'release'
         );
 
         if (semverTag === undefined && !noReleaseTag) {


### PR DESCRIPTION
# What Changed

`pr-check` also needs to know about the no-release labels

# Why

it was doing checks against no-release label and would produce misleading results

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
