### PR TITLE
only error if there are actually missing args

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -531,11 +531,13 @@ export default function parseArgs(testArgs?: string[]) {
       .map(option => `--${option}`);
     const multiple = missing.length > 1;
 
-    printCommandHelp(command);
-    signale.error(
-      `Missing required flag${multiple ? 's' : ''}: ${missing.join(', ')}`
-    );
-    process.exit(0);
+    if (missing.length > 0) {
+      printCommandHelp(command);
+      signale.error(
+        `Missing required flag${multiple ? 's' : ''}: ${missing.join(', ')}`
+      );
+      process.exit(0);
+    }
   }
 
   return autoOptions;


### PR DESCRIPTION
# What Changed

fixed a bug

# Why

even with all required args the CLI would exit

Todo:

- [ ] Add tests
- [ ] Add docs
- [x] Add SemVer label
