### PR TITLE
url isn't required for pr or pr-check

### DIFF
--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -14,7 +14,7 @@ auto pr-check --pr 24 --url http://your-ci.com
 Options
 
   --pr number [required]           The pull request number you want the labels of
-  --url string [required]          URL to associate with this status
+  --url string                     URL to associate with this status
   --onlyPublishWithReleaseLabel    Only bump version if 'release' label is on pull request
   --major string                   The name of the tag for a major version bump
   --minor string                   The name of the tag for a minor version bump

--- a/docs/pages/auto-pr.md
+++ b/docs/pages/auto-pr.md
@@ -12,7 +12,7 @@ Options
   --sha string                      Specify a custom git sha. Defaults to the HEAD for a git repo in the current
                                     repository
   --pr number [required]            The pull request number you want the labels of
-  --url string [required]           URL to associate with this status
+  --url string                      URL to associate with this status
   --state string [required]         State of the PR. ['pending', 'success', 'error', 'failure']
   --description string [required]   A description of the status
   --context string [required]       A string label to differentiate this status from others

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -239,7 +239,7 @@ const commands: ICommand[] = [
   {
     name: 'pr',
     summary: 'Set the status on a PR commit',
-    require: ['pr', 'state', 'description', 'context', 'url'],
+    require: ['pr', 'state', 'description', 'context'],
     options: [
       {
         name: 'sha',
@@ -272,7 +272,7 @@ const commands: ICommand[] = [
       ...defaultOptions
     ],
     examples: [
-      `{green $} auto pr \\\\ \n   --pr 32 \\\\ \n   --url http://your-ci.com/build/123 \\\\ \n   --state pending \\\\ \n   --description "Build still running..." \\\\ \n   --context build-check`
+      `{green $} auto pr \\\\ \n   --pr 32 \\\\ \n   --state pending \\\\ \n   --description "Build still running..." \\\\ \n   --context build-check`
     ]
   },
   {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -220,7 +220,7 @@ const commands: ICommand[] = [
   {
     name: 'pr-check',
     summary: 'Check that a pull request has a SemVer label',
-    require: ['pr', 'url'],
+    require: ['pr'],
     options: [
       pr,
       url,


### PR DESCRIPTION
# What Changed

remove url flag as required for pr and pr-check

# Why

these commands can run without the url flag

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
