### PR TITLE
Deprecate --major --minor --patch flags

### DIFF
--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -16,9 +16,6 @@ Options
   --pr number [required]           The pull request number you want the labels of
   --url string                     URL to associate with this status
   --onlyPublishWithReleaseLabel    Only bump version if 'release' label is on pull request
-  --major string                   The name of the tag for a major version bump
-  --minor string                   The name of the tag for a minor version bump
-  --patch string                   The name of the tag for a patch version bump
   --context string                 A string label to differentiate this status from others
   --noReleaseLabels string[]       Labels that will not create a release. Defaults to just 'no-release'
 

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -8,9 +8,6 @@ Get the semantic version bump for the given changes. Requires all PRs to have la
 Options
 
   --onlyPublishWithReleaseLabel    Only bump version if 'release' label is on pull request
-  --major string                   The name of the tag for a major version bump
-  --minor string                   The name of the tag for a minor version bump
-  --patch string                   The name of the tag for a patch version bump
   --noReleaseLabels string[]       Labels that will not create a release. Defaults to just 'no-release'
 
 Global Options

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -121,29 +121,6 @@ const onlyPublishWithReleaseLabel: commandLineUsage.OptionDefinition = {
   group: 'main'
 };
 
-const major: commandLineUsage.OptionDefinition = {
-  name: 'major',
-  type: String,
-  description: 'The name of the tag for a major version bump',
-  group: 'main'
-};
-
-const minor: commandLineUsage.OptionDefinition = {
-  name: 'minor',
-  type: String,
-  description: 'The name of the tag for a minor version bump',
-  group: 'main'
-};
-
-const patch: commandLineUsage.OptionDefinition = {
-  name: 'patch',
-  type: String,
-  description: 'The name of the tag for a patch version bump',
-  group: 'main'
-};
-
-const semver = [onlyPublishWithReleaseLabel, major, minor, patch];
-
 const name: commandLineUsage.OptionDefinition = {
   name: 'name',
   type: String,
@@ -224,7 +201,7 @@ const commands: ICommand[] = [
     options: [
       pr,
       url,
-      ...semver,
+      onlyPublishWithReleaseLabel,
       {
         ...context,
         defaultValue: 'ci/pr-check'
@@ -278,7 +255,7 @@ const commands: ICommand[] = [
   {
     name: 'version',
     summary: 'Get the semantic version bump for the given changes.',
-    options: [...semver, noReleaseLabels, ...defaultOptions],
+    options: [onlyPublishWithReleaseLabel, noReleaseLabels, ...defaultOptions],
     examples: [
       {
         desc: 'Get the new version using the last release to head',
@@ -546,9 +523,6 @@ export default function parseArgs(testArgs?: string[]) {
 export interface ISemverArgs {
   noReleaseLabels?: string[];
   onlyPublishWithReleaseLabel?: boolean;
-  major?: string;
-  minor?: string;
-  patch?: string;
   jira?: string;
   slack?: string;
   githubApi?: string;

--- a/src/main.ts
+++ b/src/main.ts
@@ -212,13 +212,6 @@ export async function run(args: ArgsType) {
 
   verbose.success('Loaded `auto-release` with config:', rawConfig);
 
-  Object.entries(args).forEach(([key, val]) => {
-    // tslint:disable-next-line
-    if (val === null) {
-      delete (args as any)[key];
-    }
-  });
-
   const config: IGithubReleaseOptions = {
     ...rawConfig,
     ...args,


### PR DESCRIPTION
# What Changed

Remove --major --minor --patch flags from pr-check and version

# Why

There are more versioning labels than this and that many flags is confusing. They also weren't being used. 

closes #61 

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
