### PR TITLE
Slack url via CLI

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -333,7 +333,14 @@ const commands: ICommand[] = [
         type: Boolean,
         group: 'main',
         description:
-          'Post a message to slack about the release. Make sure the SLACK_TOKEN environment variable is set.'
+          'Post a message to slack about the release. Make sure the SLACK_TOKEN environment variable is set'
+      },
+      {
+        name: 'slack-url',
+        alias: 's',
+        type: String,
+        group: 'main',
+        description: 'Slack url to post to '
       },
       ...defaultOptions
     ],
@@ -528,7 +535,6 @@ export interface ISemverArgs {
   skipReleaseLabels?: string[];
   onlyPublishWithReleaseLabel?: boolean;
   jira?: string;
-  slack?: string;
   githubApi?: string;
 }
 
@@ -555,7 +561,8 @@ export interface IPRArgs {
 
 export interface IReleaseArgs {
   dry_run?: boolean;
-  slack?: string;
+  slack?: boolean;
+  'slack-url'?: string;
   no_version_prefix?: boolean;
   use_version?: string;
 }

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -70,7 +70,7 @@ export interface IGithubReleaseOptions {
   labels?: IVersionLabels;
   logger: ILogger;
   jira?: string;
-  slack?: string;
+  'slack-url'?: string;
   githubApi?: string;
   name?: string;
   email?: string;
@@ -103,7 +103,7 @@ export default class GithubRelease {
     releaseOptions: IGithubReleaseOptions = { logger: dummyLog() }
   ) {
     this.jira = releaseOptions.jira;
-    this.slack = releaseOptions.slack;
+    this.slack = releaseOptions['slack-url'];
     this.userLabels = releaseOptions.labels || new Map();
     this.changelogTitles = releaseOptions.changelogTitles || {};
     this.logger = releaseOptions.logger;


### PR DESCRIPTION
# What Changed

`--slack` can be:

- a string (this already worked)
- a boolean - when boolean auto will look in the auto.config for a string (this didn't work, args.slack would have overridden config.slack)

# Why

closes #23 

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
