### PR TITLE
slack CLI flag can be the slack url

### DIFF
--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -32,8 +32,9 @@ Options
   --no-version-prefix    Use the version as the tag without the 'v' prefix
   --jira string          Jira base URL
   --use-version          Version number to publish as. Defaults to reading from the package.json.
-  -s, --slack            Post a message to slack about the release. Make sure the SLACK_TOKEN
-                         environment variable is set.
+  -s, --slack string     Url to post a slack message to about the release. If slack url supplied via
+                         autorc this flag can act as a boolean.  Make sure the SLACK_TOKEN environment
+                         variable is set.
 
 Global Options
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -330,10 +330,10 @@ const commands: ICommand[] = [
       {
         name: 'slack',
         alias: 's',
-        type: Boolean,
+        type: String,
         group: 'main',
         description:
-          'Post a message to slack about the release. Make sure the SLACK_TOKEN environment variable is set.'
+          'Url to post a slack message to about the release. If slack url supplied via autorc this flag can act as a boolean.  Make sure the SLACK_TOKEN environment variable is set.'
       },
       ...defaultOptions
     ],
@@ -528,7 +528,6 @@ export interface ISemverArgs {
   skipReleaseLabels?: string[];
   onlyPublishWithReleaseLabel?: boolean;
   jira?: string;
-  slack?: string;
   githubApi?: string;
 }
 
@@ -555,7 +554,7 @@ export interface IPRArgs {
 
 export interface IReleaseArgs {
   dry_run?: boolean;
-  slack?: string;
+  slack?: string | boolean;
   no_version_prefix?: boolean;
   use_version?: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -201,7 +201,7 @@ export async function run(args: ArgsType) {
   const explorer = cosmiconfig('auto');
   const result = await explorer.search();
 
-  let rawConfig = {};
+  let rawConfig: cosmiconfig.Config = {};
 
   const prefixRelease = (release: string) =>
     args.no_version_prefix || release.startsWith('v') ? release : `v${release}`;
@@ -215,7 +215,8 @@ export async function run(args: ArgsType) {
   const config: IGithubReleaseOptions = {
     ...rawConfig,
     ...args,
-    logger
+    logger,
+    slack: typeof args.slack === 'string' ? args.slack : rawConfig.slack
   };
 
   await setGitUser(config);


### PR DESCRIPTION
# What Changed

`--slack` can be:

- a string (this already worked)
- a boolean - when boolean auto will look in the auto.config for a string (this didn't work, args.slack would have overridden config.slack)

# Why

closes #23 

Todo:

- [ ] Add tests
- [x] Add docs
- [x] Add SemVer label
