### PR TITLE
add --version flag

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import chalk from 'chalk';
 import commandLineArgs from 'command-line-args';
 import commandLineUsage from 'command-line-usage';
@@ -28,11 +31,18 @@ const help: commandLineUsage.OptionDefinition = {
   type: Boolean
 };
 
-const mainDefinitions: commandLineUsage.OptionDefinition[] = [
+const mainDefinitions = [
   { name: 'command', type: String, defaultOption: true },
   {
     ...help,
     description: 'Display the help output. Works on each command as well'
+  },
+  {
+    name: 'version',
+    alias: 'V',
+    type: Boolean,
+    description: "Display auto-release-cli's version",
+    group: 'misc'
   }
 ];
 
@@ -457,6 +467,12 @@ function printCommandHelp(command: ICommand) {
   console.log(commandLineUsage(sections));
 }
 
+function printVersion() {
+  const packagePath = path.join(__dirname, '../../package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  console.log(`v${packageJson.version}`);
+}
+
 function styleTypes(
   command: ICommand,
   option: commandLineUsage.OptionDefinition
@@ -488,6 +504,10 @@ export default function parseArgs(testArgs?: string[]) {
   });
   const argv = mainOptions._unknown || [];
   const command = commands.find(c => c.name === mainOptions.command);
+
+  if (!command && mainOptions.version) {
+    return printVersion();
+  }
 
   if (!command) {
     return printRootHelp();


### PR DESCRIPTION
# What Changed

adds a root level flag to display `auto`s version

# Why

closes #106

Todo:

- [ ] Add tests
- [ ] Add docs
- [x] Add SemVer label
