### PR TITLE
Don't crash when there is no author hash in the package.json

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -83,11 +83,11 @@ async function setGitUser(args: IGithubReleaseOptions) {
   const packageJson = JSON.parse(await readFile('package.json', 'utf-8'));
   let { name, email } = args;
 
-  if (!name) {
+  if (!name && packageJson.author) {
     ({ name } = packageJson.author);
   }
 
-  if (!email) {
+  if (!email && packageJson.author) {
     ({ email } = packageJson.author);
   }
 


### PR DESCRIPTION
# What Changed

```
~/d/p/a/j/omakase  $ yarn auto init                                                                                                                                                         2 changed files  master
yarn run v1.12.3
$ /Users/ortatherox/dev/projects/artsy/js/omakase/node_modules/.bin/auto init
TypeError: Cannot read property 'name' of undefined
    at /Users/ortatherox/dev/projects/artsy/js/omakase/node_modules/auto-release-cli/dist/main.js:155:52
    at step (/Users/ortatherox/dev/projects/artsy/js/omakase/node_modules/auto-release-cli/dist/main.js:44:23)
    at Object.next (/Users/ortatherox/dev/projects/artsy/js/omakase/node_modules/auto-release-cli/dist/main.js:25:53)
    at fulfilled (/Users/ortatherox/dev/projects/artsy/js/omakase/node_modules/auto-release-cli/dist/main.js:16:58)
````

as our root [`package.json`](https://github.com/omakase-js/omakase/blob/5e9594c12b4ddb13a008c61613a056db5a8c978b/package.json) does not contain an authors section (it's never deployed)

# Why

No crashes = 👍 

Todo:

- [x] Add tests (figured this is too small)
- [x] Add docs (n/a)
- [ ] Add SemVer label (not admin)