### PR TITLE
Convert 'Github' to 'GitHub'

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -29,4 +29,4 @@ Individuals or teams representing projects in official capacity, such as via off
 
 ## Attribution
 
-This Code of Conduct is partly inspired by and based on those of Amazon, CocoaPods, Github, Microsoft, thoughtbot, and on the Contributor Covenant version 1.4.1.
+This Code of Conduct is partly inspired by and based on those of Amazon, CocoaPods, GitHub, Microsoft, thoughtbot, and on the Contributor Covenant version 1.4.1.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Release Features:
 - Release every merge to master based on a PR labels
 - Skip a release with the `skip-release` label
 - Generate a changelog with fancy headers, authors, and monorepo package association
-- Generate a Github release
+- Generate a GitHub release
 
 Pull Request Interaction Features:
 

--- a/docs/home.md
+++ b/docs/home.md
@@ -2,7 +2,7 @@
 
 # auto release
 
-## CLI tools to help facilitate semantic versioning based on Github PR labels.
+## CLI tools to help facilitate semantic versioning based on GitHub PR labels.
 
 :::
 

--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -26,7 +26,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-comment.md
+++ b/docs/pages/auto-comment.md
@@ -24,7 +24,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-init.md
+++ b/docs/pages/auto-init.md
@@ -32,7 +32,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-label.md
+++ b/docs/pages/auto-label.md
@@ -16,7 +16,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -26,7 +26,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-pr.md
+++ b/docs/pages/auto-pr.md
@@ -24,7 +24,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -43,7 +43,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -19,7 +19,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -17,7 +17,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    Github API to use
+  --githubApi string    GitHub API to use
 
 Examples
 

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -45,7 +45,7 @@ After that, you need to set up the labels on your github project. The types of l
 - Versioning Labels - used to calculate version numbers and make releases. To change them refer to [this](./autorc.md#versioning-labels).
 - Changelog Labels - These labels do not effect the version calculation but they will change the section the PR displays in the changelog. These are customizable too, and you can even add your own sections. Read more [here](./autorc.md#changelog-titles)
 
-To create the labels for your project on Github, run the following command with your `GH_TOKEN`.
+To create the labels for your project on GitHub, run the following command with your `GH_TOKEN`.
 
 ```sh
 GH_TOKEN=YOUR_TOKEN auto create-labels

--- a/docs/pages/introduction.md
+++ b/docs/pages/introduction.md
@@ -9,7 +9,7 @@ Release Features:
 - Release every merge to master based on a PR labels
 - Skip a release with the `skip-release` label
 - Generate a changelog with fancy headers, authors, and monorepo package association
-- Generate a Github release
+- Generate a GitHub release
 
 Pull Request Interaction Features:
 

--- a/docs/pages/troubleshooting.md
+++ b/docs/pages/troubleshooting.md
@@ -48,7 +48,7 @@ mkdir ~/.ssh/ && echo -e "Host github.YOUR_COMPANY.com\n\tStrictHostKeyChecking 
 
 If you've encountered any of these errors you'll probably run into this problem. If the whole release process doesn't complete you can end up in a state when `auto` published the new version, but doesn't push that back to github. To fix this just bump the version number to the "previously published version".
 
-## Cannot read owner and package name from Github URL in package.json
+## Cannot read owner and package name from GitHub URL in package.json
 
 This means that you do not have a repository set in your package.json. Add something along the line of:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-release-cli",
-  "description": "CLI tools to help facilitate semantic versioning based on Github PR labels.",
+  "description": "CLI tools to help facilitate semantic versioning based on GitHub PR labels.",
   "version": "0.37.1",
   "author": {
     "name": "Andrew Lisowski",

--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GithubRelease generateReleaseNotes should allow user to configure section headings 1`] = `
+exports[`GitHubRelease generateReleaseNotes should allow user to configure section headings 1`] = `
 "#### 💥  Breaking Change
 
 - First [#1234](https://custom-git.com/pull/1234) (adam@dierkens.com)
@@ -22,7 +22,7 @@ exports[`GithubRelease generateReleaseNotes should allow user to configure secti
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`GithubRelease getCommits should resolve authors with PR commits 1`] = `
+exports[`GitHubRelease getCommits should resolve authors with PR commits 1`] = `
 Array [
   Object {
     "authorEmail": "adam@dierkens.com",

--- a/src/__tests__/git-changed-packages.test.ts
+++ b/src/__tests__/git-changed-packages.test.ts
@@ -1,4 +1,4 @@
-import Github from '../git';
+import GitHub from '../git';
 import { dummyLog } from '../utils/logger';
 
 const exec = jest.fn();
@@ -10,7 +10,7 @@ jest.mock('../utils/exec-promise.ts', () => (...args) => exec(...args));
 
 describe('changedPackages ', async () => {
   test('should return nothing without a package directory', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -23,7 +23,7 @@ describe('changedPackages ', async () => {
   });
 
   test('should match files in package directory', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -38,7 +38,7 @@ describe('changedPackages ', async () => {
   });
 
   test('should match files in package directory with @scope/ names', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -1,4 +1,4 @@
-import Github from '../git';
+import GitHub from '../git';
 import { dummyLog } from '../utils/logger';
 
 const logger = dummyLog();
@@ -66,20 +66,20 @@ describe('github', () => {
 
   describe('authenticate', () => {
     test('should reject without token', async () => {
-      const gh = new Github({ logger, owner: 'Adam Dierkens', repo: 'test' });
+      const gh = new GitHub({ logger, owner: 'Adam Dierkens', repo: 'test' });
       expect.assertions(1);
 
       try {
         await gh.authenticate();
       } catch (error) {
         expect(error.message.trim()).toBe(
-          'Authentication needs a Github token. Try setting up an access token https://github.com/settings/tokens/new'
+          'Authentication needs a GitHub token. Try setting up an access token https://github.com/settings/tokens/new'
         );
       }
     });
 
     test('should use token', async () => {
-      const gh = new Github({ logger, owner: 'Adam Dierkens', repo: 'test' });
+      const gh = new GitHub({ logger, owner: 'Adam Dierkens', repo: 'test' });
 
       await gh.authenticate('MyToken');
       expect(authenticate).toHaveBeenCalledWith({
@@ -89,7 +89,7 @@ describe('github', () => {
     });
 
     test('should use options token', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -106,7 +106,7 @@ describe('github', () => {
 
   describe('getLabels', async () => {
     test('successful', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -131,7 +131,7 @@ describe('github', () => {
     });
 
     test('handles errors', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -143,7 +143,7 @@ describe('github', () => {
   });
 
   test('publish', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -156,7 +156,7 @@ describe('github', () => {
   });
 
   test('getFirstCommit ', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -169,7 +169,7 @@ describe('github', () => {
   });
 
   test('getSha', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -180,7 +180,7 @@ describe('github', () => {
   });
 
   test('getGitLog ', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -196,7 +196,7 @@ describe('github', () => {
   });
 
   test('getUser', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -209,7 +209,7 @@ describe('github', () => {
   });
 
   test('createStatus', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -231,7 +231,7 @@ describe('github', () => {
   });
 
   test('getProject', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -245,7 +245,7 @@ describe('github', () => {
 
   describe('createComment', async () => {
     test('should post comment if none exists', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -259,7 +259,7 @@ describe('github', () => {
     });
 
     test('should delete old comment', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -283,7 +283,7 @@ describe('github', () => {
     });
 
     test('should be able to comment in different contexts', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -325,7 +325,7 @@ describe('github', () => {
   });
 
   test('getCommitsForPR', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -341,7 +341,7 @@ describe('github', () => {
   });
 
   test('getCommitsForPR', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -357,7 +357,7 @@ describe('github', () => {
   });
 
   test('getUserByUsername', async () => {
-    const gh = new Github({
+    const gh = new GitHub({
       logger,
       owner: 'Adam Dierkens',
       repo: 'test',
@@ -375,7 +375,7 @@ describe('github', () => {
 
   describe('getUserByEmail', async () => {
     test('exists', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -392,7 +392,7 @@ describe('github', () => {
     });
 
     test('doesnt exist', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -411,7 +411,7 @@ describe('github', () => {
 
   describe('getLatestRelease ', async () => {
     test('has tag ', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -424,7 +424,7 @@ describe('github', () => {
     });
 
     test('no tags', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -439,7 +439,7 @@ describe('github', () => {
     });
 
     test('handles errors', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -452,7 +452,7 @@ describe('github', () => {
 
   describe('getProjectLabels ', () => {
     test('return labels', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -470,7 +470,7 @@ describe('github', () => {
     });
 
     test('throw for errors', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -483,7 +483,7 @@ describe('github', () => {
 
   describe('createLabel', () => {
     test('should create a label', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',
@@ -502,7 +502,7 @@ describe('github', () => {
     });
 
     test('throw for errors', async () => {
-      const gh = new Github({
+      const gh = new GitHub({
         logger,
         owner: 'Adam Dierkens',
         repo: 'test',

--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -1,4 +1,4 @@
-import GithubRelease, { VersionLabel } from '../github-release';
+import GitHubRelease, { VersionLabel } from '../github-release';
 import { normalizeCommits } from '../log-parse';
 import SEMVER from '../semver';
 import { dummyLog } from '../utils/logger';
@@ -86,7 +86,7 @@ jest.mock('../utils/slack.ts', () => () => slackSpy());
 jest.mock('../utils/package-config', () => async () => ({}));
 jest.mock('../utils/github-token', () => async () => ({}));
 
-describe('GithubRelease', () => {
+describe('GitHubRelease', () => {
   beforeEach(() => {
     getGitLog.mockClear();
     publish.mockClear();
@@ -98,7 +98,7 @@ describe('GithubRelease', () => {
   });
 
   test('should use options owner, repo, and token', async () => {
-    const gh = new GithubRelease({
+    const gh = new GitHubRelease({
       owner: 'Andrew',
       repo: 'test',
       token: 'MY_TOKENss'
@@ -112,13 +112,13 @@ describe('GithubRelease', () => {
 
   describe('getCommits', async () => {
     test('should default to HEAD', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       await gh.getCommits('12345');
       expect(getGitLog).toHaveBeenCalled();
     });
 
     test('should use configured HEAD', async () => {
-      const gh = new GithubRelease({ owner: 'Adam Dierkens', repo: 'test' });
+      const gh = new GitHubRelease({ owner: 'Adam Dierkens', repo: 'test' });
       await gh.getCommits('12345', '1234');
       expect(getGitLog).toHaveBeenCalled();
     });
@@ -131,7 +131,7 @@ describe('GithubRelease', () => {
       ];
 
       getGitLog.mockReturnValueOnce(commits);
-      const gh = new GithubRelease({ owner: 'Adam Dierkens', repo: 'test' });
+      const gh = new GitHubRelease({ owner: 'Adam Dierkens', repo: 'test' });
       await gh.getCommits('12345', '1234');
       expect(getUserByUsername).not.toHaveBeenCalled();
     });
@@ -167,7 +167,7 @@ describe('GithubRelease', () => {
         name: 'Adam Dierkens'
       });
 
-      const gh = new GithubRelease({ owner: 'Adam Dierkens', repo: 'test' });
+      const gh = new GitHubRelease({ owner: 'Adam Dierkens', repo: 'test' });
       const modifiedCommits = await gh.getCommits('12345', '1234');
       expect(getUserByUsername).toHaveBeenCalled();
       expect(modifiedCommits).toMatchSnapshot();
@@ -175,37 +175,37 @@ describe('GithubRelease', () => {
   });
 
   test('publish', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.publish('release notes', '1.2.3');
     expect(publish).toHaveBeenCalled();
   });
 
   test('getLabels', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.getLabels(123);
     expect(getLabels).toHaveBeenCalled();
   });
 
   test('getLatestRelease', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.getLatestRelease();
     expect(getLatestRelease).toHaveBeenCalled();
   });
 
   test('getLatestRelease', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.getPullRequest(22);
     expect(getLatestRelease).toHaveBeenCalled();
   });
 
   test('getSha', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.getSha();
     expect(getLatestRelease).toHaveBeenCalled();
   });
 
   test('createStatus', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.createStatus({
       state: 'pending',
       sha: '',
@@ -218,20 +218,20 @@ describe('GithubRelease', () => {
   });
 
   test('createComment', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.createComment('Some long message', 22);
     expect(createComment).toHaveBeenCalled();
   });
 
   test('getPullRequests', async () => {
-    const gh = new GithubRelease();
+    const gh = new GitHubRelease();
     await gh.getPullRequests({ state: 'closed' });
     expect(getPullRequests).toHaveBeenCalled();
   });
 
   describe('addToChangelog', async () => {
     test("creates new changelog if one didn't exist", async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       await gh.addToChangelog(
         '# My new Notes',
         'klajsdlfk4lj51l43k5hj234l',
@@ -242,14 +242,14 @@ describe('GithubRelease', () => {
     });
 
     test("creates new changelog if one didn't exist", async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       await gh.addToChangelog('# My new Notes', 'v1.0.0', 'v1.0.0', false);
 
       expect(writeSpy.mock.calls[0][1].includes(`v1.0.1`)).toBe(true);
     });
 
     test('prepends to old changelog', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
 
       existsSync.mockReturnValueOnce(true);
       readResult = '# My old Notes';
@@ -263,7 +263,7 @@ describe('GithubRelease', () => {
     });
 
     test('should be able to configure message', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const message = 'pony foo';
 
       existsSync.mockReturnValueOnce(true);
@@ -281,7 +281,7 @@ describe('GithubRelease', () => {
   });
 
   test('postToSlack', async () => {
-    const gh = new GithubRelease(undefined, {
+    const gh = new GitHubRelease(undefined, {
       logger: dummyLog(),
       slack: 'https://custom-slack-url'
     });
@@ -291,17 +291,17 @@ describe('GithubRelease', () => {
 
   describe('generateReleaseNotes', async () => {
     test('should default to HEAD', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       expect(await gh.generateReleaseNotes('1234')).toBe('');
     });
 
     test('should use configured HEAD', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       expect(await gh.generateReleaseNotes('1234', '123')).toBe('');
     });
 
     test('should allow user to configure section headings', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
 
       const commits = [
         makeCommitFromMsg('First (#1234)'),
@@ -322,7 +322,7 @@ describe('GithubRelease', () => {
 
   describe('getSemverBump', () => {
     test('default to patch', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First'),
         makeCommitFromMsg('Second'),
@@ -335,7 +335,7 @@ describe('GithubRelease', () => {
     });
 
     test('should use higher version', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second'),
@@ -349,7 +349,7 @@ describe('GithubRelease', () => {
     });
 
     test('should not publish a release', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
@@ -365,7 +365,7 @@ describe('GithubRelease', () => {
     });
 
     test('should publish a release', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
@@ -381,7 +381,7 @@ describe('GithubRelease', () => {
     });
 
     test('should default to publish a prepatch', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
@@ -397,7 +397,7 @@ describe('GithubRelease', () => {
     });
 
     test('should not publish a release in onlyPublishWithReleaseLabel without label', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
@@ -413,7 +413,7 @@ describe('GithubRelease', () => {
     });
 
     test('should publish a release in onlyPublishWithReleaseLabel with label', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const commits = [
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
@@ -435,7 +435,7 @@ describe('GithubRelease', () => {
       labels.set(SEMVER.patch, 'Version: Patch');
       labels.set('release', 'Deploy');
 
-      const gh = new GithubRelease(undefined, {
+      const gh = new GitHubRelease(undefined, {
         logger,
         labels
       });
@@ -464,7 +464,7 @@ describe('GithubRelease', () => {
 
   describe('addLabelsToProject', () => {
     test('should add labels', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const labels = new Map<VersionLabel, string>();
       labels.set(SEMVER.major, '1');
       labels.set(SEMVER.minor, '2');
@@ -478,7 +478,7 @@ describe('GithubRelease', () => {
     });
 
     test('should not add old labels', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const labels = new Map<VersionLabel, string>();
       labels.set(SEMVER.major, '1');
       labels.set(SEMVER.minor, '2');
@@ -491,7 +491,7 @@ describe('GithubRelease', () => {
     });
 
     test('should add release label in onlyPublishWithReleaseLabel mode', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const labels = new Map<VersionLabel, string>();
       labels.set('release', 'deploy');
 
@@ -503,7 +503,7 @@ describe('GithubRelease', () => {
     });
 
     test('should add skip-release label not in onlyPublishWithReleaseLabel mode', async () => {
-      const gh = new GithubRelease();
+      const gh = new GitHubRelease();
       const labels = new Map<VersionLabel, string>();
       labels.set('skip-release', 'no!');
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -84,7 +84,7 @@ const defaultOptions = [
   {
     name: 'githubApi',
     type: String,
-    description: 'Github API to use',
+    description: 'GitHub API to use',
     group: 'misc'
   }
 ];

--- a/src/git.ts
+++ b/src/git.ts
@@ -10,7 +10,7 @@ import settingsUrl from './utils/settings-url';
 
 const gitlog = promisify(gitlogNode);
 
-export interface IGithubOptions {
+export interface IGitHubOptions {
   owner: string;
   repo: string;
   version?: string;
@@ -28,7 +28,7 @@ export interface IPRInfo {
   state: 'error' | 'failure' | 'pending' | 'success';
 }
 
-class GithubAPIError extends Error {
+class GitHubAPIError extends Error {
   constructor(api: string, args: object, origError: Error) {
     super(
       `Error calling github: ${api}\n\twith: ${JSON.stringify(args)}.\n\t${
@@ -41,18 +41,18 @@ class GithubAPIError extends Error {
 const makeCommentIdentifier = (context: string) =>
   `<!-- GITHUB_RELEASE COMMENT: ${context} -->`;
 
-export default class Github {
+export default class GitHub {
   public readonly ghub: GHub;
   public readonly baseUrl: string;
-  public readonly options: IGithubOptions;
+  public readonly options: IGitHubOptions;
   private readonly logger: ILogger;
 
-  constructor(options: IGithubOptions) {
+  constructor(options: IGitHubOptions) {
     this.logger = options.logger;
     this.options = options;
     this.baseUrl = this.options.baseUrl || 'https://api.github.com';
 
-    this.logger.veryVerbose.info(`Initializing Github with: ${this.baseUrl}`);
+    this.logger.veryVerbose.info(`Initializing GitHub with: ${this.baseUrl}`);
     this.ghub = new GHub({
       baseUrl: this.baseUrl,
       headers: {
@@ -65,7 +65,7 @@ export default class Github {
   public async authenticate(authToken?: string): Promise<void> {
     if (authToken === undefined && this.options.token === undefined) {
       throw new Error(
-        `Authentication needs a Github token. Try setting up an access token ${settingsUrl(
+        `Authentication needs a GitHub token. Try setting up an access token ${settingsUrl(
           this.baseUrl
         )}`
       );
@@ -73,14 +73,14 @@ export default class Github {
 
     const token = authToken || this.options.token;
 
-    this.logger.veryVerbose.info('Authenticating with Github.');
+    this.logger.veryVerbose.info('Authenticating with GitHub.');
 
     this.ghub.authenticate({
       type: 'token',
       token: token!
     });
 
-    this.logger.veryVerbose.info('Sucessfully authenticated with Github.');
+    this.logger.veryVerbose.info('Sucessfully authenticated with GitHub.');
 
     return Promise.resolve();
   }
@@ -108,7 +108,7 @@ export default class Github {
     } catch (e) {
       if (e.status === 404) {
         this.logger.verbose.info(
-          "Couldn't find latest release on Github, using first commit."
+          "Couldn't find latest release on GitHub, using first commit."
         );
         return this.getFirstCommit();
       }
@@ -152,7 +152,7 @@ export default class Github {
 
       return labels.data.map(l => l.name);
     } catch (e) {
-      throw new GithubAPIError('listLabelsOnIssue', args, e);
+      throw new GitHubAPIError('listLabelsOnIssue', args, e);
     }
   }
 
@@ -178,7 +178,7 @@ export default class Github {
 
       return labels.data.map(l => l.name);
     } catch (e) {
-      throw new GithubAPIError('getProjectLabels', args, e);
+      throw new GitHubAPIError('getProjectLabels', args, e);
     }
   }
 
@@ -254,7 +254,7 @@ export default class Github {
     const result = await this.ghub.repos.createStatus(args);
 
     this.logger.veryVerbose.info('Got response from createStatues\n', result);
-    this.logger.verbose.info('Created status on Github.');
+    this.logger.verbose.info('Created status on GitHub.');
 
     return result;
   }
@@ -273,13 +273,13 @@ export default class Github {
     });
 
     this.logger.veryVerbose.info('Got response from createLabel\n', result);
-    this.logger.verbose.info('Created label on Github.');
+    this.logger.verbose.info('Created label on GitHub.');
 
     return result;
   }
 
   public async getProject() {
-    this.logger.verbose.info('Getting project from Github');
+    this.logger.verbose.info('Getting project from GitHub');
 
     await this.authenticate();
 
@@ -381,7 +381,7 @@ export default class Github {
   }
 
   public async publish(releaseNotes: string, tag: string) {
-    this.logger.verbose.info('Creating release on Github for tag:', tag);
+    this.logger.verbose.info('Creating release on GitHub for tag:', tag);
 
     await this.authenticate();
 
@@ -393,7 +393,7 @@ export default class Github {
     });
 
     this.logger.veryVerbose.info('Got response from createRelease\n', result);
-    this.logger.verbose.info('Created Github release.');
+    this.logger.verbose.info('Created GitHub release.');
 
     return result;
   }

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -5,14 +5,14 @@ import { inc, ReleaseType } from 'semver';
 import signale from 'signale';
 import { promisify } from 'util';
 
-import Github, { IGithubOptions, IPRInfo } from './git';
+import GitHub, { IGitHubOptions, IPRInfo } from './git';
 import generateReleaseNotes, {
   IExtendedCommit,
   normalizeCommits
 } from './log-parse';
 import SEMVER, { calculateSemVerBump, IVersionLabels } from './semver';
 import exec from './utils/exec-promise';
-import getGithubToken from './utils/github-token';
+import getGitHubToken from './utils/github-token';
 import { dummyLog } from './utils/logger';
 import getConfigFromPackageJson from './utils/package-config';
 import postToSlack from './utils/slack';
@@ -66,7 +66,7 @@ export interface ILogger {
   veryVerbose: signale.Signale<signale.DefaultMethods>;
 }
 
-export interface IGithubReleaseOptions {
+export interface IGitHubReleaseOptions {
   labels?: IVersionLabels;
   logger: ILogger;
   jira?: string;
@@ -79,7 +79,7 @@ export interface IGithubReleaseOptions {
   };
 }
 
-export interface IOptionalGithubOptions {
+export interface IOptionalGitHubOptions {
   owner?: string;
   repo?: string;
   baseUrl?: string;
@@ -89,8 +89,8 @@ export interface IOptionalGithubOptions {
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 
-export default class GithubRelease {
-  private readonly github: Promise<Github>;
+export default class GitHubRelease {
+  private readonly github: Promise<GitHub>;
   private readonly userLabels: IVersionLabels;
   private readonly changelogTitles: { [label: string]: string };
   private readonly logger: ILogger;
@@ -100,8 +100,8 @@ export default class GithubRelease {
   private readonly slack?: string;
 
   constructor(
-    options?: IOptionalGithubOptions,
-    releaseOptions: IGithubReleaseOptions = { logger: dummyLog() }
+    options?: IOptionalGitHubOptions,
+    releaseOptions: IGitHubReleaseOptions = { logger: dummyLog() }
   ) {
     this.jira = releaseOptions.jira;
     this.githubApi = releaseOptions.githubApi || 'https://api.github.com';
@@ -124,15 +124,15 @@ export default class GithubRelease {
         args.baseUrl = this.githubApi;
       }
 
-      this.logger.verbose.info('Initializing Github API with:\n', args);
-      this.github = Promise.resolve(new Github(args));
+      this.logger.verbose.info('Initializing GitHub API with:\n', args);
+      this.github = Promise.resolve(new GitHub(args));
     } else {
       this.logger.verbose.info('Getting repo information from package.json');
 
       this.github = getConfigFromPackageJson().then(async gOptions => {
-        const token = await getGithubToken(this.githubApi);
+        const token = await getGitHubToken(this.githubApi);
 
-        const finalOptions: IGithubReleaseOptions & IGithubOptions = {
+        const finalOptions: IGitHubReleaseOptions & IGitHubOptions = {
           ...options,
           ...gOptions,
           logger: this.logger,
@@ -149,11 +149,11 @@ export default class GithubRelease {
           options && options.repo ? options.repo : gOptions.repo;
 
         this.logger.verbose.info(
-          'Initializing Github API with:\n',
+          'Initializing GitHub API with:\n',
           finalOptions
         );
 
-        return new Github(finalOptions);
+        return new GitHub(finalOptions);
       });
     }
   }

--- a/src/init.ts
+++ b/src/init.ts
@@ -15,12 +15,12 @@ async function getFlags() {
     {
       type: 'input',
       name: 'repo',
-      message: 'Github Project Repository (press enter to use package.json)'
+      message: 'GitHub Project Repository (press enter to use package.json)'
     },
     {
       type: 'input',
       name: 'owner',
-      message: 'Github Project Owner (press enter to use package.json)'
+      message: 'GitHub Project Owner (press enter to use package.json)'
     },
     {
       type: 'confirm',
@@ -36,7 +36,7 @@ async function getFlags() {
     {
       type: 'input',
       name: 'githubApi',
-      message: 'Github API to use (press enter to use public)'
+      message: 'GitHub API to use (press enter to use public)'
     },
     {
       type: 'confirm',

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,10 +7,10 @@ import { promisify } from 'util';
 
 import { ArgsType } from './cli/args';
 import { IPRInfo } from './git';
-import GithubRelease, {
+import GitHubRelease, {
   defaultChangelogTitles,
   defaultLabels,
-  IGithubReleaseOptions
+  IGitHubReleaseOptions
 } from './github-release';
 
 import init from './init';
@@ -79,7 +79,7 @@ async function getCurrentVersion(
   return lastVersion;
 }
 
-async function setGitUser(args: IGithubReleaseOptions) {
+async function setGitUser(args: IGitHubReleaseOptions) {
   const packageJson = JSON.parse(await readFile('package.json', 'utf-8'));
   let { name, email } = args;
 
@@ -100,7 +100,7 @@ async function setGitUser(args: IGithubReleaseOptions) {
   }
 }
 
-async function getVersion(githubRelease: GithubRelease, args: ArgsType) {
+async function getVersion(githubRelease: GitHubRelease, args: ArgsType) {
   const lastRelease = await githubRelease.getLatestRelease();
 
   return githubRelease.getSemverBump(
@@ -113,7 +113,7 @@ async function getVersion(githubRelease: GithubRelease, args: ArgsType) {
 
 async function makeChangelog(
   args: ArgsType,
-  githubRelease: GithubRelease,
+  githubRelease: GitHubRelease,
   log: signale.Signale<signale.DefaultMethods>,
   prefixRelease: (release: string) => string,
   veryVerbose: signale.Signale<signale.DefaultMethods>,
@@ -148,7 +148,7 @@ async function makeChangelog(
 
 async function makeRelease(
   args: ArgsType,
-  githubRelease: GithubRelease,
+  githubRelease: GitHubRelease,
   log: signale.Signale<signale.DefaultMethods>,
   prefixRelease: (release: string) => string,
   veryVerbose: signale.Signale<signale.DefaultMethods>,
@@ -179,7 +179,7 @@ async function makeRelease(
   }
 
   const prefixed = prefixRelease(version);
-  log.info(`Publishing ${prefixed} to Github.`);
+  log.info(`Publishing ${prefixed} to GitHub.`);
 
   if (!args['dry-run']) {
     await githubRelease.publish(releaseNotes, prefixed);
@@ -214,7 +214,7 @@ export async function run(args: ArgsType) {
 
   verbose.success('Loaded `auto-release` with config:', rawConfig);
 
-  const config: IGithubReleaseOptions = {
+  const config: IGitHubReleaseOptions = {
     ...rawConfig,
     ...args,
     logger,
@@ -234,7 +234,7 @@ export async function run(args: ArgsType) {
 
   verbose.success('Using SEMVER labels:', '\n', semVerLabels);
 
-  const githubRelease = new GithubRelease(
+  const githubRelease = new GitHubRelease(
     {
       owner: args.owner,
       repo: args.repo
@@ -381,7 +381,7 @@ export async function run(args: ArgsType) {
         };
       }
 
-      verbose.info('Posting comment to Github\n', msg);
+      verbose.info('Posting comment to GitHub\n', msg);
 
       if (!args['dry-run']) {
         await githubRelease.createStatus({

--- a/src/utils/__tests__/package-config.test.ts
+++ b/src/utils/__tests__/package-config.test.ts
@@ -36,7 +36,7 @@ test('should throw without an owner', async () => {
     await packageConfig();
   } catch (error) {
     expect(error.message.trim()).toBe(
-      'Cannot read owner and package name from Github URL in package.json'
+      'Cannot read owner and package name from GitHub URL in package.json'
     );
   }
 });
@@ -54,7 +54,7 @@ test('should throw without an package name', async () => {
     await packageConfig();
   } catch (error) {
     expect(error.message.trim()).toBe(
-      'Cannot read owner and package name from Github URL in package.json'
+      'Cannot read owner and package name from GitHub URL in package.json'
     );
   }
 });

--- a/src/utils/github-token.ts
+++ b/src/utils/github-token.ts
@@ -9,7 +9,7 @@ const registry = registryUrl();
 // tslint:disable-next-line
 const normalizedRegistry = registry.replace('http:', '').replace('https:', '');
 
-export default async function getGithubToken(apiUrl: string): Promise<string> {
+export default async function getGitHubToken(apiUrl: string): Promise<string> {
   if (process.env.GH_TOKEN) {
     return process.env.GH_TOKEN;
   }

--- a/src/utils/package-config.ts
+++ b/src/utils/package-config.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import parseGithubUrl from 'parse-github-url';
+import parseGitHubUrl from 'parse-github-url';
 import { promisify } from 'util';
 
 export interface IRepoConfig {
@@ -32,13 +32,13 @@ export default async function getConfigFromPackageJson(): Promise<IRepoConfig> {
   }
 
   const { owner, name } =
-    parseGithubUrl(
+    parseGitHubUrl(
       typeof repository === 'string' ? repository : repository.url
     ) || ({} as any);
 
   if (!owner || !name) {
     throw new Error(
-      'Cannot read owner and package name from Github URL in package.json'
+      'Cannot read owner and package name from GitHub URL in package.json'
     );
   }
 


### PR DESCRIPTION
# What Changed

```diff
- Github
+ GitHub
```

# Why

As someone who has run a thing with a 2nd uppercase letter for a good few years (CocoaPods), it's awesome to see people using the right capitalization.

Todo:

- [ ] Add SemVer label

I validated that tests and builds pass, so unless you're doing some funky dynamic code I couldn't verify everything looked fine.