### PR TITLE
Include a log when creating a new labels about what those labels are

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -23,6 +23,7 @@ const getUserByUsername = jest.fn();
 const getProjectLabels = jest.fn();
 const createLabel = jest.fn();
 const getPullRequests = jest.fn();
+const getRepoMetadata = jest.fn();
 
 getProject.mockReturnValue({
   data: { html_url: 'https://custom-git.com' }
@@ -48,7 +49,8 @@ jest.mock('../git.ts', () => (...args) => {
     getUserByEmail,
     getProjectLabels,
     createLabel,
-    getPullRequests
+    getPullRequests,
+    getRepoMetadata
   };
 });
 
@@ -463,6 +465,12 @@ describe('GithubRelease', () => {
   });
 
   describe('addLabelsToProject', () => {
+    beforeEach(() => {
+      getRepoMetadata.mockResolvedValue({
+        html_url: 'https://github.com/web/site'
+      });
+    });
+
     test('should add labels', async () => {
       const gh = new GithubRelease();
       const labels = new Map<VersionLabel, string>();
@@ -487,9 +495,10 @@ describe('GithubRelease', () => {
 
       await gh.addLabelsToProject(labels);
 
-      expect(mockLogger.log.log).toHaveBeenCalledWith('Created labels: ', [
-        'patch'
-      ]);
+      expect(mockLogger.log.log).toHaveBeenCalledWith('Created labels: patch');
+      expect(mockLogger.log.log).toHaveBeenCalledWith(
+        '\nYou can see these, and more at https://github.com/web/site/labels'
+      );
     });
 
     test('should not add old labels', async () => {

--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -477,6 +477,21 @@ describe('GithubRelease', () => {
       expect(createLabel).toHaveBeenCalledWith(SEMVER.patch, '3');
     });
 
+    test('should log that it has created the labels', async () => {
+      const mockLogger = dummyLog();
+      mockLogger.log.log = jest.fn();
+
+      const gh = new GithubRelease(undefined, { logger: mockLogger });
+      const labels = new Map<VersionLabel, string>();
+      labels.set(SEMVER.patch, '3');
+
+      await gh.addLabelsToProject(labels);
+
+      expect(mockLogger.log.log).toHaveBeenCalledWith('Created labels: ', [
+        'patch'
+      ]);
+    });
+
     test('should not add old labels', async () => {
       const gh = new GithubRelease();
       const labels = new Map<VersionLabel, string>();

--- a/src/git.ts
+++ b/src/git.ts
@@ -80,9 +80,19 @@ export default class Github {
       token: token!
     });
 
-    this.logger.veryVerbose.info('Sucessfully authenticated with Github.');
+    this.logger.veryVerbose.info('Successfully authenticated with Github.');
 
     return Promise.resolve();
+  }
+
+  // Looks like: https://developer.github.com/v3/repos/#get
+  public async getRepoMetadata(): Promise<any> {
+    await this.authenticate();
+
+    return (await this.ghub.repos.get({
+      owner: this.options.owner.toLowerCase(),
+      repo: this.options.repo.toLowerCase()
+    })).data;
   }
 
   public async getLatestRelease(): Promise<string> {

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -328,9 +328,8 @@ export default class GithubRelease {
   ) {
     const client = await this.github;
     const oldLabels = await client.getProjectLabels();
-
-    await Promise.all(
-      [...labels.entries()].map(async ([versionLabel, customLabel]) => {
+    const labelsToCreate = [...labels.entries()].filter(
+      ([versionLabel, customLabel]) => {
         if (oldLabels && oldLabels.includes(customLabel)) {
           return;
         }
@@ -343,9 +342,18 @@ export default class GithubRelease {
           return;
         }
 
+        return true;
+      }
+    );
+
+    await Promise.all(
+      labelsToCreate.map(async ([versionLabel, customLabel]) => {
         await client.createLabel(versionLabel, customLabel);
       })
     );
+
+    const justLabelNames = labelsToCreate.map(([name]) => name);
+    this.logger.log.log('Created labels: ', justLabelNames);
   }
 
   public async getSemverBump(

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -352,8 +352,13 @@ export default class GithubRelease {
       })
     );
 
+    const repoMetadata = await client.getRepoMetadata();
+
     const justLabelNames = labelsToCreate.map(([name]) => name);
-    this.logger.log.log('Created labels: ', justLabelNames);
+    this.logger.log.log(`Created labels: ${justLabelNames}`);
+    this.logger.log.log(
+      `\nYou can see these, and more at ${repoMetadata.html_url}/labels`
+    );
   }
 
   public async getSemverBump(


### PR DESCRIPTION
# What Changed

```sh
$ yarn auto create-labels
$
```

`->`

```sh
$ yarn auto create-labels
Created labels: [x, y, z]
$
```

# Why

I didn't know what the labels would be, and even after creating them I didn't.

I couldn't find any other uses of the `logger.log` which makes me think this is the wrong way to do it?

Todo:

- [x] Add tests
- [x] Add docs (n/a)
- [x] Add SemVer label