### PR TITLE
Fix custom labels not respected by the semver checker

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -431,11 +431,12 @@ describe('GitHubRelease', () => {
     });
 
     test('should be able to configure labels', async () => {
-      const labels = new Map();
-      labels.set(SEMVER.major, 'Version: Major');
-      labels.set(SEMVER.minor, 'Version: Minor');
-      labels.set(SEMVER.patch, 'Version: Patch');
-      labels.set('release', 'Deploy');
+      const labels = {
+        [SEMVER.major]: 'Version: Major',
+        [SEMVER.minor]: 'Version: Minor',
+        [SEMVER.patch]: 'Version: Patch',
+        release: 'Deploy'
+      };
 
       const gh = new GitHubRelease(undefined, {
         logger,

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -67,7 +67,9 @@ export interface ILogger {
 }
 
 export interface IGitHubReleaseOptions {
-  labels?: IVersionLabels;
+  labels?: {
+    [label: string]: string;
+  };
   logger: ILogger;
   jira?: string;
   slack?: string;
@@ -106,9 +108,12 @@ export default class GitHubRelease {
     this.jira = releaseOptions.jira;
     this.githubApi = releaseOptions.githubApi || 'https://api.github.com';
     this.slack = releaseOptions.slack;
-    this.userLabels = releaseOptions.labels || new Map();
     this.changelogTitles = releaseOptions.changelogTitles || {};
     this.logger = releaseOptions.logger;
+    this.userLabels = new Map(Object.entries(releaseOptions.labels || {}) as [
+      VersionLabel,
+      string
+    ][]);
 
     if (options && options.owner && options.repo && options.token) {
       this.logger.verbose.info('Options contain repo information.');


### PR DESCRIPTION
# What Changed

config/rc supplies labels as a string to string object, convert it to a Map so creating a new Map with it works later on.

# Why

This happened when I converted the label maps to proper javascript `Map`s. The following line will not work as expected when creating a new `Map` because object is not an `Iterable`. The result was that none of the `userLabels` were actually added to the `versionLabels`.

```ts
const versionLabels = new Map([...defaultLabels, ...this.userLabels]);
```

closes #127 

Todo:

- [x] Add tests
- [ ] Add docs
- [x] Add SemVer label
