### PR TITLE
Changes the verbose logging so that it doesn't leak tokens

### DIFF
--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -129,7 +129,18 @@ export default class GitHubRelease {
         args.baseUrl = this.githubApi;
       }
 
-      this.logger.verbose.info('Initializing GitHub API with:\n', args);
+      // So that --verbose can be used on public CIs
+      const tokenlessArgs = {
+        ...args,
+        token: args.token
+          ? `[Token starting with ${args.token.substring(0, 4)}]`
+          : undefined
+      };
+
+      this.logger.verbose.info(
+        'Initializing GitHub API with:\n',
+        tokenlessArgs
+      );
       this.github = Promise.resolve(new GitHub(args));
     } else {
       this.logger.verbose.info('Getting repo information from package.json');


### PR DESCRIPTION
# What Changed

While debugging, I wanted to run with `--verbose` to see what was up. Unfortunately, this leaked my GH token to the public. Which was fine because I was reading my logs carefully, but better to just not let it happen. This amends logging 

```
ℹ  info      Initializing GitHub API with:
 { owner: 'artsy',
  repo: 'reaction',
  version: '9.1.56',
  logger:
   { log:
      Signale {
        _interactive: false,
        _config: [Object],
        log: [Function: bound _logger] },
     verbose:
      Signale {
        _interactive: false,
        log: [Function: bound _logger] },
     veryVerbose:
      Signale {
        _interactive: false,
        log: [Function: bound _logger] } },
  token: '[Real token]',
  baseUrl: 'https://api.github.com' }
```

Now it will just show the first 4 chars.