### PR TITLE
Flags all snake-case and autorc options all camelCase

### DIFF
--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -25,7 +25,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-comment.md
+++ b/docs/pages/auto-comment.md
@@ -24,7 +24,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-init.md
+++ b/docs/pages/auto-init.md
@@ -32,7 +32,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package.json
   --owner string        Version number to publish as. Defaults to reading from the package.json
-  --githubApi string    GitHub API to use
+  --github-api string    GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-label.md
+++ b/docs/pages/auto-label.md
@@ -16,7 +16,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -13,12 +13,11 @@ auto pr-check --pr 24 --url http://your-ci.com
 
 Options
 
-  --pr number [required]           The pull request number you want the labels of
-  --url string                     URL to associate with this status
-  --onlyPublishWithReleaseLabel    Only bump version if 'release' label is on pull request
-  --context string                 A string label to differentiate this status from others
-  --skipReleaseLabels string[]     Labels that will not create a release. Defaults to just
-                                   'skip-release'
+  --pr number [required]               The pull request number you want the labels of
+  --url string                         URL to associate with this status
+  --only-publish-with-release-label    Only bump version if 'release' label is on pull request
+  --context string                     A string label to differentiate this status from others
+  --skip-release-labels string[]       Labels that will not create a release. Defaults to just 'skip-release'
 
 Global Options
 
@@ -27,7 +26,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-pr.md
+++ b/docs/pages/auto-pr.md
@@ -23,7 +23,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -43,7 +43,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -19,7 +19,7 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 

--- a/docs/pages/auto-version.md
+++ b/docs/pages/auto-version.md
@@ -7,8 +7,8 @@ Get the semantic version bump for the given changes. Requires all PRs to have la
 
 Options
 
-  --onlyPublishWithReleaseLabel    Only bump version if 'release' label is on pull request
-  --skipReleaseLabels string[]     Labels that will not create a release. Defaults to just 'skip-release'
+  --only-publish-with-release-label    Only bump version if 'release' label is on pull request
+  --skip-release-labels string[]       Labels that will not create a release. Defaults to just 'skip-release'
 
 Global Options
 
@@ -17,13 +17,13 @@ Global Options
   -w, --very-verbose    Show a lot more logs
   --repo string         The repo to set the status on. Defaults to looking in the package definition for the platform
   --owner string        Version number to publish as. Defaults to reading from the package definition for the platform
-  --githubApi string    GitHub API to use
+  --github-api string   GitHub API to use
 
 Examples
 
   Get the new version using the last release     $ auto version
   to head
-  Skip releases with multiple labels             $ auto version --skipReleaseLabels
+  Skip releases with multiple labels             $ auto version --skip-release-labels
                                                  documentation CI
 
 ```
@@ -47,7 +47,7 @@ To not create a release for a pull request add the `skip-release` label. Any pul
 You can configure multiple labels to skip releasing as well. To do this use the `skipReleaseLabels` options. This can also be configured via the [.autorc](./autorc.md#multiple-no-version).
 
 ```sh
-auto version --skipReleaseLabels project-files --skipReleaseLabels documentation
+auto version --skip-release-labels project-files --skip-release-labels documentation
 ```
 
 ## Configure Versioning Labels

--- a/docs/pages/autorc.md
+++ b/docs/pages/autorc.md
@@ -1,6 +1,6 @@
 # `auto` RC File
 
-All options for the CLI tools can also be configured via the `.autorc`.
+All options for the CLI tools can also be configured via the `.autorc`. As CLI options you supply them in snake-case (`--foo-bar`), but as `.autorc` options you supply them in camelCase (`fooBar`),
 
 We use [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) to find your config, so that means you can define this file a variety of ways. By default, Cosmiconfig will start at the root of your project and start to search up the directory tree for the following:
 

--- a/docs/pages/getting-started.md
+++ b/docs/pages/getting-started.md
@@ -8,7 +8,7 @@ yarn add -D auto-release-cli
 
 ## Enterprise
 
-If you are using enterprise github `auto-release` lets you configure the github API URL that it uses. You can configure this by using the CLI option `--githubApi`, by setting the value in your [.autorc](./autorc.md#githubApi), or during `auto init`.
+If you are using enterprise github `auto-release` lets you configure the github API URL that it uses. You can configure this by using the CLI option `--github-api`, by setting the value in your [.autorc](./autorc.md#githubApi), or during `auto init`.
 
 ### Project already published
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -82,7 +82,7 @@ const defaultOptions = [
     group: 'misc'
   },
   {
-    name: 'githubApi',
+    name: 'github-api',
     type: String,
     description: 'GitHub API to use',
     group: 'misc'
@@ -126,7 +126,7 @@ const jira: commandLineUsage.OptionDefinition = {
 };
 
 const onlyPublishWithReleaseLabel: commandLineUsage.OptionDefinition = {
-  name: 'onlyPublishWithReleaseLabel',
+  name: 'only-publish-with-release-label',
   type: Boolean,
   description: "Only bump version if 'release' label is on pull request",
   group: 'main'
@@ -161,7 +161,7 @@ const message: commandLineUsage.OptionDefinition = {
 };
 
 const skipReleaseLabels: commandLineUsage.OptionDefinition = {
-  name: 'skipReleaseLabels',
+  name: 'skip-release-labels',
   type: String,
   group: 'main',
   multiple: true,
@@ -280,7 +280,7 @@ const commands: ICommand[] = [
       },
       {
         desc: 'Skip releases with multiple labels',
-        example: '{green $} auto version --skipReleaseLabels documentation CI'
+        example: '{green $} auto version --skip-release-labels documentation CI'
       }
     ]
   },
@@ -507,6 +507,7 @@ function styleTypes(
 export default function parseArgs(testArgs?: string[]) {
   const mainOptions = commandLineArgs(mainDefinitions, {
     stopAtFirstUnknown: true,
+    camelCase: true,
     argv: testArgs
   });
   const argv = mainOptions._unknown || [];
@@ -580,10 +581,10 @@ export interface IPRArgs {
 }
 
 export interface IReleaseArgs {
-  'dry-run'?: boolean;
+  dryRun?: boolean;
   slack?: string | boolean;
-  'no-version-prefix'?: boolean;
-  'use-version'?: string;
+  noVersionPrefix?: boolean;
+  useVersion?: string;
 }
 
 export interface IChangelogArgs {
@@ -596,12 +597,12 @@ export interface ICommentArgs {
 }
 
 export interface IInitArgs {
-  'only-labels'?: boolean;
+  onlyLabels?: boolean;
 }
 
 export interface ILogArgs {
   verbose?: boolean;
-  'very-verbose'?: boolean;
+  veryVerbose?: boolean;
 }
 
 export type ArgsType = {

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -35,7 +35,7 @@ export interface IGitHubReleaseOptions {
   repo?: string;
   skipReleaseLabels: string[];
   onlyPublishWithReleaseLabel?: boolean;
-  'no-version-prefix'?: boolean;
+  noVersionPrefix?: boolean;
   changelogTitles?: {
     [label: string]: string;
   };
@@ -180,7 +180,7 @@ export default class GitHubRelease {
 
     const date = new Date().toDateString();
     const prefixed =
-      this.releaseOptions['no-version-prefix'] ||
+      this.releaseOptions.noVersionPrefix ||
       (version && version.startsWith('v'))
         ? version
         : `v${version}`;

--- a/src/init.ts
+++ b/src/init.ts
@@ -25,7 +25,7 @@ async function getFlags() {
     },
     {
       type: 'confirm',
-      name: 'no-version-prefix',
+      name: 'noVersionPrefix',
       message: 'Use the version as the tag without the `v` prefix?',
       initial: 'no'
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -63,11 +63,7 @@ export class AutoRelease {
     this.args = args;
     this.plugins = plugins;
     this.logger = createLog(
-      args['very-verbose']
-        ? 'veryVerbose'
-        : args.verbose
-        ? 'verbose'
-        : undefined
+      args.veryVerbose ? 'veryVerbose' : args.verbose ? 'verbose' : undefined
     );
 
     this.hooks = {
@@ -143,7 +139,7 @@ export class AutoRelease {
   }
 
   public async init() {
-    await init(this.args['only-labels']);
+    await init(this.args.onlyLabels);
   }
 
   public async createLabels() {
@@ -211,7 +207,7 @@ export class AutoRelease {
     this.args.target_url = this.args.url;
     delete this.args.url;
 
-    if (!this.args['dry-run']) {
+    if (!this.args.dryRun) {
       await this.githubRelease.createStatus(this.args as IPRInfo);
     } else {
       this.logger.verbose.info('`pr` dry run complete.');
@@ -284,7 +280,7 @@ export class AutoRelease {
 
     this.logger.verbose.info('Posting comment to GitHub\n', msg);
 
-    if (!this.args['dry-run']) {
+    if (!this.args.dryRun) {
       await this.githubRelease.createStatus({
         ...this.args,
         ...msg
@@ -389,7 +385,7 @@ export class AutoRelease {
 
     this.logger.log.info('New Release Notes\n', releaseNotes);
 
-    if (!this.args['dry-run']) {
+    if (!this.args.dryRun) {
       const currentVersion = await this.getCurrentVersion(lastRelease);
 
       await this.githubRelease.addToChangelog(
@@ -426,7 +422,7 @@ export class AutoRelease {
     this.logger.log.info(`Using release notes:\n${releaseNotes}`);
 
     const version =
-      this.args['use-version'] || (await this.getCurrentVersion(lastRelease));
+      this.args.useVersion || (await this.getCurrentVersion(lastRelease));
 
     if (!version) {
       this.logger.log.error('Could not calculate next version from last tag.');
@@ -436,7 +432,7 @@ export class AutoRelease {
     const prefixed = this.prefixRelease(version);
     this.logger.log.info(`Publishing ${prefixed} to GitHub.`);
 
-    if (!this.args['dry-run']) {
+    if (!this.args.dryRun) {
       await this.githubRelease.publish(releaseNotes, prefixed);
 
       if (this.args.slack) {
@@ -453,7 +449,7 @@ export class AutoRelease {
       throw this.createErrorMessage();
     }
 
-    return this.githubRelease.releaseOptions['no-version-prefix'] ||
+    return this.githubRelease.releaseOptions.noVersionPrefix ||
       release.startsWith('v')
       ? release
       : `v${release}`;


### PR DESCRIPTION
# What Changed

💥 All CLI flags are now snake-case, supplied via the .autorc they are camalCase.

NOTE: Merge after #131

# Why

it was all mixed up now it is consistent in the CLI and in the JSON you don't have to use snake case

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors
