### PR TITLE
Increase number of commits to scan for

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -180,7 +180,7 @@ export default class GitHub {
   public async getGitLog(start: string, end = 'HEAD'): Promise<ICommit[]> {
     const log = await gitlog({
       repo: process.cwd(),
-      number: 99999999,
+      number: Number.MAX_SAFE_INTEGER,
       fields: ['hash', 'authorName', 'authorEmail', 'rawBody'],
       branch: `${start.trim()}..${end.trim()}`
     });

--- a/src/git.ts
+++ b/src/git.ts
@@ -180,6 +180,7 @@ export default class GitHub {
   public async getGitLog(start: string, end = 'HEAD'): Promise<ICommit[]> {
     const log = await gitlog({
       repo: process.cwd(),
+      number: 99999999,
       fields: ['hash', 'authorName', 'authorEmail', 'rawBody'],
       branch: `${start.trim()}..${end.trim()}`
     });

--- a/src/types/gitlog.d.ts
+++ b/src/types/gitlog.d.ts
@@ -12,6 +12,7 @@ declare module 'gitlog' {
     repo: string;
     fields: string[];
     branch: string;
+    number: number;
   }
 
   export default function gitlog(


### PR DESCRIPTION
# What Changed

Increase number of commits that `gitlog` returns.

# Why

If a user is in onlyPublishWithReleaseLabel mode or uses `skip-release` a bunch then a bunch of commits need to be scanned. We need to look at all of them. 

I will be surprised if someone needed more than `Number.MAX_SAFE_INTEGER`.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors
