### PR TITLE
convert subcommand flags camelcase too

### DIFF
--- a/src/cli/__tests__/args.test.ts
+++ b/src/cli/__tests__/args.test.ts
@@ -47,4 +47,11 @@ describe('root parser', () => {
       command: 'label'
     });
   });
+
+  test('should parse args as camelCase', () => {
+    expect(parseArgs('changelog -d'.split(' '))).toEqual({
+      command: 'changelog',
+      dryRun: true
+    });
+  });
 });

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -538,7 +538,7 @@ export default function parseArgs(testArgs?: string[]) {
 
   const autoOptions: ArgsType = {
     command: mainOptions.command,
-    ...commandLineArgs(options, { argv })._all
+    ...commandLineArgs(options, { argv, camelCase: true })._all
   };
 
   if (command.require) {


### PR DESCRIPTION
# What Changed

subcommands now have their flags converted to camelcase as well

# Why

#138

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors
