### PR TITLE
A few missed "await exec" refactors

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -300,7 +300,7 @@ describe('GitHubRelease', () => {
         'v0.0.0',
         message
       );
-      expect(execSpy.mock.calls[1][0].includes(message)).toBe(true);
+      expect(execSpy.mock.calls[1][1].includes(message)).toBe(true);
     });
   });
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -10,7 +10,7 @@ import generateReleaseNotes, {
   normalizeCommits
 } from './log-parse';
 import SEMVER, { calculateSemVerBump } from './semver';
-import exec from './utils/exec-promise';
+import execPromise from './utils/exec-promise';
 import { dummyLog, ILogger } from './utils/logger';
 import postToSlack from './utils/slack';
 
@@ -186,8 +186,8 @@ export default class GitHubRelease {
     await writeFile('CHANGELOG.md', newChangelog);
     this.logger.verbose.info('Wrote new changelog to filesystem.');
 
-    await exec('git add CHANGELOG.md');
-    await exec(`git commit -m '${message}' --no-verify`);
+    await execPromise('git', ['add', 'CHANGELOG.md']);
+    await execPromise('git', ['commit', '-m', message, '--no-verify']);
     this.logger.verbose.info('Commited new changelog.');
   }
 


### PR DESCRIPTION
# What Changed

A few calls to exec were still using the old format.

# Why

It broke committing the changelog.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
