### PR TITLE
Maintain context when spawning git process

### DIFF
--- a/src/utils/exec-promise.ts
+++ b/src/utils/exec-promise.ts
@@ -9,7 +9,11 @@ import { spawn } from 'child_process';
  */
 export default async function execPromise(cmd: string, args?: string[]) {
   return new Promise<string>((completed, reject) => {
-    const child = spawn(cmd, args || []);
+    const child = spawn(cmd, args || [], {
+      cwd: process.cwd(),
+      env: process.env,
+      shell: true
+    });
 
     let allStdout = '';
     child.stdout.on('data', async data => {


### PR DESCRIPTION
Fixes #155

# What Changed

Ensure `cwd` and `env` are preserved as well as running the commands in a `shell` context.

# Why

To fix git commands losing things like the configured user. 

Todo:

- [ ] Add tests
- [ ] Add docs
- [x] Add yourself to contributors (run `yarn contributors:add`)
