### PR TITLE
Ensure commit messages are strings

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -300,7 +300,7 @@ describe('GitHubRelease', () => {
         'v0.0.0',
         message
       );
-      expect(execSpy.mock.calls[1][1].includes(message)).toBe(true);
+      expect(execSpy.mock.calls[1][1].includes(`"${message}"`)).toBe(true);
     });
   });
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -187,7 +187,7 @@ export default class GitHubRelease {
     this.logger.verbose.info('Wrote new changelog to filesystem.');
 
     await execPromise('git', ['add', 'CHANGELOG.md']);
-    await execPromise('git', ['commit', '-m', message, '--no-verify']);
+    await execPromise('git', ['commit', '-m', `"${message}"`, '--no-verify']);
     this.logger.verbose.info('Commited new changelog.');
   }
 

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -80,7 +80,7 @@ export default class NPMPlugin implements IPlugin {
           'version',
           version,
           '-m',
-          'Bump version to: %s [skip ci]'
+          '"Bump version to: %s [skip ci]"'
         ]);
         await execPromise('npm', ['publish']);
         await execPromise('git', [


### PR DESCRIPTION
# What Changed

Changelog commit message needs to be a string

# Why

broke the release

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
