### PR TITLE
Only warn about git user when it isn't set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,6 @@
 # v2.0.1 (Mon Jan 07 2019)
 
-#### 🐛  Bug Fix
-
-- Ensure commit messages are strings [#158](https://github.com/intuit/auto-release/pull/158) ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Maintain context when spawning git process [#157](https://github.com/intuit/auto-release/pull/157) ([@zephraph](https://github.com/zephraph))
-
-#### Authors: 2
-
-- Andrew Lisowski ([@hipstersmoothie](https://github.com/hipstersmoothie))
-- Justin Bennett ([@zephraph](https://github.com/zephraph))
-
----
-
-# v2.0.1 (Mon Jan 07 2019)
-
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - Ensure commit messages are strings [#158](https://github.com/intuit/auto-release/pull/158) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Maintain context when spawning git process [#157](https://github.com/intuit/auto-release/pull/157) ([@zephraph](https://github.com/zephraph))
@@ -28,17 +14,17 @@
 
 # v2.0.0 (Mon Jan 07 2019)
 
-#### 💥  Breaking Change
+#### 💥 Breaking Change
 
 - Flags all snake-case and autorc options all camelCase [#138](https://github.com/intuit/auto-release/pull/138) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Tappable Auto - Plugin System [#131](https://github.com/intuit/auto-release/pull/131) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🚀  Enhancement
+#### 🚀 Enhancement
 
 - Only set git user in CI env [#151](https://github.com/intuit/auto-release/pull/151) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Plugins Options: load official, npm package, or path [#144](https://github.com/intuit/auto-release/pull/144) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 
-#### 🐛  Bug Fix
+#### 🐛 Bug Fix
 
 - A few missed "await exec" refactors [#154](https://github.com/intuit/auto-release/pull/154) ([@hipstersmoothie](https://github.com/hipstersmoothie))
 - Raise an error, and fail execution when a sub-command fails [#146](https://github.com/intuit/auto-release/pull/146) ([@hipstersmoothie](https://github.com/hipstersmoothie) [@orta](https://github.com/orta))

--- a/src/main.ts
+++ b/src/main.ts
@@ -472,23 +472,23 @@ export class AutoRelease {
   private async setGitUser() {
     const { isCi } = envCi();
 
-    if (!isCi) {
-      this.logger.log.note(
-        `Detected CI environment, will not set git user.
-
-If a command fails manually run:
-
-  - git config user.email your@email.com
-  - git config user.name "Your Name"`
-      );
-      return;
-    }
-
     try {
       // If these values are not set git config will exit with an error
       await execPromise('git', ['config', 'user.email']);
       await execPromise('git', ['config', 'user.name']);
     } catch (error) {
+      if (!isCi) {
+        this.logger.log.note(
+          `Detected CI environment, will not set git user.
+
+If a command fails manually run:
+
+  - git config user.email your@email.com
+  - git config user.name "Your Name"`
+        );
+        return;
+      }
+
       this.hooks.getAuthor.tap('Arguments', () =>
         this.githubRelease ? (this.githubRelease.releaseOptions as IAuthor) : {}
       );


### PR DESCRIPTION
# What Changed

See title

# Why

I was running changelog locally and it was warning me even though it didn't need to

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
