### PR TITLE
Await all hook promises

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -337,7 +337,7 @@ export class AutoRelease {
     }
 
     await this.makeChangelog();
-    this.hooks.publish.promise(version);
+    await this.hooks.publish.promise(version);
     await this.makeRelease();
   }
 


### PR DESCRIPTION
# What Changed

Await the result of hooks.publish.promise.

# Why

gotta await those promises! If the npm published rejected, `auto` would still run `release` because it had not awaited the result.

closes #161 (I was wrong)

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
