### PR TITLE
Improve setGitUser messaging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -479,7 +479,7 @@ export class AutoRelease {
     } catch (error) {
       if (!isCi) {
         this.logger.log.note(
-          `Detected CI environment, will not set git user.
+          `Detected local environment, will not set git user. This happens automatically in a CI environment.
 
 If a command fails manually run:
 


### PR DESCRIPTION
# What Changed

Change the message presented to the user when setGitUser is run locally.

# Why

The message was backwards, we didn't detect a CI env.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
