### PR TITLE
Parse string authors

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "env-ci": "^3.1.3",
     "gitlog": "^3.1.2",
     "node-fetch": "2.3.0",
+    "parse-author": "^2.0.0",
     "parse-github-url": "1.0.2",
     "registry-url": "4.0.0",
     "semver": "^5.6.0",

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import parseAuthor from 'parse-author';
 import { promisify } from 'util';
 
 import { AutoRelease, IPlugin } from '../../main';
@@ -23,7 +24,13 @@ export default class NPMPlugin implements IPlugin {
       const packageJson = JSON.parse(await readFile('package.json', 'utf-8'));
 
       if (packageJson.author) {
-        return packageJson.author;
+        const { author } = packageJson;
+
+        if (typeof author === 'string') {
+          return parseAuthor(author);
+        }
+
+        return author;
       }
     });
 

--- a/src/types/parse-author.d.ts
+++ b/src/types/parse-author.d.ts
@@ -1,0 +1,4 @@
+declare module 'parse-author' {
+  function parseAuthor(author: string): string;
+  export = parseAuthor;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,6 +1764,11 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+author-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/author-regex/-/author-regex-1.0.0.tgz#d08885be6b9bbf9439fe087c76287245f0a81450"
+  integrity sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=
+
 autoprefixer@^9.4.2:
   version "9.4.3"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.3.tgz#c97384a8fd80477b78049163a91bbc725d9c41d9"
@@ -8449,6 +8454,13 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+
+parse-author@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/parse-author/-/parse-author-2.0.0.tgz#d3460bf1ddd0dfaeed42da754242e65fb684a81f"
+  integrity sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=
+  dependencies:
+    author-regex "^1.0.0"
 
 parse-bmfont-ascii@^1.0.3:
   version "1.0.6"


### PR DESCRIPTION
# What Changed

see title

# Why

It's common to specify an author as a string.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
