### PR TITLE
Config takes precedence for author and repo

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -510,11 +510,14 @@ If a command fails manually run:
   }
 
   private async getRepo() {
-    this.hooks.getRepository.tap('None', () =>
-      this.githubRelease
-        ? (this.githubRelease.releaseOptions as IRepository)
-        : {}
-    );
+    if (
+      this.githubRelease &&
+      this.githubRelease.releaseOptions.repo &&
+      this.githubRelease.releaseOptions.owner
+    ) {
+      return this.githubRelease.releaseOptions as IRepository;
+    }
+
     return this.hooks.getRepository.promise();
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -489,11 +489,15 @@ If a command fails manually run:
         return;
       }
 
-      this.hooks.getAuthor.tap('Arguments', () =>
-        this.githubRelease ? (this.githubRelease.releaseOptions as IAuthor) : {}
-      );
+      if (!this.githubRelease) {
+        return;
+      }
 
-      const { name, email } = await this.hooks.getAuthor.promise();
+      let { email, name } = this.githubRelease.releaseOptions;
+      const packageAuthor = await this.hooks.getAuthor.promise();
+
+      email = email || packageAuthor.email;
+      name = name || packageAuthor.name;
 
       if (email) {
         await execPromise('git', ['config', 'user.email', `"${email}"`]);


### PR DESCRIPTION
# What Changed

see title

# Why

As a user I would expect the config to override any hooks because I set it

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
