### PR TITLE
Fix generating the changelog with custom labels

### DIFF
--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -1,3 +1,4 @@
+import { defaultLabels } from '../github-release';
 import generateReleaseNotes, {
   createUserLink,
   filterServiceAccounts,
@@ -40,7 +41,8 @@ describe('createUserLink', () => {
           owner: '',
           repo: '',
           baseUrl: 'https://github.custom.com/',
-          changelogTitles: {}
+          changelogTitles: {},
+          versionLabels: defaultLabels
         }
       )
     ).toBe(undefined);
@@ -73,7 +75,8 @@ describe('createUserLink', () => {
           owner: '',
           repo: '',
           baseUrl: 'https://github.custom.com/',
-          changelogTitles: {}
+          changelogTitles: {},
+          versionLabels: defaultLabels
         }
       )
     ).toBe('default@email.com');
@@ -235,6 +238,7 @@ const options = {
   baseUrl: 'https://github.custom.com/foobar/auto-release',
   jira: 'https://jira.custom.com/browse',
   logger,
+  versionLabels: defaultLabels,
   changelogTitles: {
     major: '💥  Breaking Change',
     minor: '🚀  Enhancement',

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -142,6 +142,7 @@ export default class GitHubRelease {
       repo: this.github.options.repo,
       baseUrl: project.html_url,
       jira: this.releaseOptions.jira,
+      versionLabels: this.versionLabels,
       changelogTitles: {
         ...defaultChangelogTitles,
         ...this.changelogTitles


### PR DESCRIPTION
# What Changed

gotta actually use the custom version labels for the changelog split

# Why

Fixing these informative logs https://github.com/artsy/renovate-config/blob/master/CHANGELOG.md

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
