### PR TITLE
String arg parse fail on null

### DIFF
--- a/src/cli/__tests__/args.test.ts
+++ b/src/cli/__tests__/args.test.ts
@@ -34,9 +34,15 @@ describe('root parser', () => {
   });
 
   test('should exit when required arg is not included', () => {
-    // @ts-ignore
-    process.exit = jest.fn();
+    process.exit = jest.fn() as any;
     parseArgs(['pr']);
+    expect(process.exit).toHaveBeenCalled();
+  });
+
+  test('should exit when required string is provided as flag', () => {
+    console.log = jest.fn() as any;
+    process.exit = jest.fn() as any;
+    parseArgs(['pr-check', '--pr', '24', '--url']);
     expect(process.exit).toHaveBeenCalled();
   });
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -543,7 +543,12 @@ export default function parseArgs(testArgs?: string[]) {
 
   if (command.require) {
     const missing = command.require
-      .filter(option => !autoOptions.hasOwnProperty(option))
+      .filter(
+        option =>
+          !autoOptions.hasOwnProperty(option) ||
+          // tslint:disable-next-line strict-type-predicates
+          autoOptions[option as keyof ArgsType] === null
+      )
       .map(option => `--${option}`);
     const multiple = missing.length > 1;
 


### PR DESCRIPTION
# What Changed

see title

# Why

if a user provided something like `auto pr-check --pr 12 --url`. It would get past the required check when it should have errorred immediately

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
