### PR TITLE
Tappable Changelog

### DIFF
--- a/docs/pages/plugins.md
+++ b/docs/pages/plugins.md
@@ -46,13 +46,102 @@ auto shipit --plugins npm NPM_PACKAGE_NAME ../path/to/plugin.js
 
 Plugins work by hooking into various actions that `auto` has to do in order to facilitate a release or interact with your GitHub repo. The hooks that it exposes are:
 
-- beforeRun - Happens before anything is done. This is a great place to check for platform specific secrets such as a NPM token.
-- getAuthor - Get git author
-- getPreviousVersion - Get the previous version
-- getRepository - Get owner/repo
-- publish - Publish the package
+#### beforeRun
 
-### Example Plugin - NPM
+Happens before anything is done. This is a great place to check for platform specific secrets such as a NPM token.
+
+```ts
+auto.hooks.beforeRun.tapPromise('NPM', async config => {
+  if (!process.env.NPM_TOKEN) {
+    throw new Error('NPM Token is needed for the NPM plugin!');
+  }
+});
+```
+
+#### getAuthor
+
+Get git author. Typically from a package distribution description file.
+
+```ts
+auto.hooks.getAuthor.tapPromise('NPM', async () => {
+  const { author } = JSON.parse(await readFile('package.json', 'utf-8'));
+
+  if (author) {
+    return author;
+  }
+});
+```
+
+#### getPreviousVersion
+
+Get the previous version. Typically from a package distribution description file.
+
+```ts
+auto.hooks.getPreviousVersion.tapPromise('NPM', async prefixRelease => {
+  const { version } = JSON.parse(await readFile('package.json', 'utf-8'));
+
+  if (version) {
+    return prefixRelease(
+      JSON.parse(await readFile('package.json', 'utf-8')).version
+    );
+  }
+});
+```
+
+#### getRepository
+
+Get owner and repo. Typically from a package distribution description file.
+
+```ts
+auto.hooks.getRepository.tapPromise('NPM', async () => {
+  const owner = // get the owner from package.json
+  const repo = // get the repo from package.json
+
+  return {
+    owner,
+    repo
+  }
+});
+```
+
+#### modifyChangelog
+
+Change how the changelog renders lines. The hooks provides the default line renderer so you don't have to change much.
+
+This plugin would change all the bullet points in the changelog to star emojis.
+
+```ts
+auto.hooks.modifyChangelog.tapPromise('NPM', async (commits, renderLine) =>
+  commits.map(commit =>
+    renderLine(commit).map(line => `${line.replace('-', ':star:')}\n`)
+  )
+);
+```
+
+#### publish
+
+Publish the package to some package distributor. Must push the tags to github!
+
+```ts
+auto.hooks.publish.tapPromise('NPM', async (version: SEMVER) => {
+  await execPromise('npm', [
+    'version',
+    version,
+    '-m',
+    'Bump version to: %s [skip ci]'
+  ]);
+  await execPromise('npm', ['publish']);
+  await execPromise('git', [
+    'push',
+    '--follow-tags',
+    '--set-upstream',
+    'origin',
+    '$branch'
+  ]);
+});
+```
+
+### Example Plugin - NPM (simple)
 
 To create a plugin simply make a class with an `apply` method and tap into the hooks you need.
 

--- a/src/__tests__/__snapshots__/log-parse.test.ts.snap
+++ b/src/__tests__/__snapshots__/log-parse.test.ts.snap
@@ -59,24 +59,6 @@ exports[`generateReleaseNotes should create note for jira commits without labels
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should create sections for packages 1`] = `
-"#### 💥  Breaking Change
-
-- woot [#12343](https://github.custom.com/foobar/auto-release/pull/12343) (adam@dierkens.com)
-- \`foobar/release\`, \`foobar/party\`
-  - [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052): Some Feature [#12345](https://github.custom.com/foobar/auto-release/pull/12345) (adam@dierkens.com)
-  - [PLAYA-5052](https://jira.custom.com/browse/PLAYA-5052): Some Feature - Revert [#12345](https://github.custom.com/foobar/auto-release/pull/12345) (adam@dierkens.com)
-
-#### 🏠  Internal
-
-- \`foobar/release\`
-  - Another Feature [#1234](https://github.custom.com/foobar/auto-release/pull/1234) (adam@dierkens.com)
-
-#### Authors: 1
-
-- Adam Dierkens (adam@dierkens.com)"
-`;
-
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `
 "#### 🐛  Bug Fix
 

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -412,19 +412,24 @@ describe('AutoRelease', () => {
       auto.githubRelease!.addToChangelog = addToChangelog;
       auto.githubRelease!.generateReleaseNotes = jest.fn();
 
-      await auto.changelog({ dryRun: true });
+      await auto.changelog({ from: 'v1.0.0', dryRun: true });
       expect(addToChangelog).not.toHaveBeenCalled();
     });
 
     test('should add to changelog', async () => {
-      const auto = new AutoRelease({ command: 'comment', ...defaults });
+      const auto = new AutoRelease({
+        command: 'changelog',
+        plugins: [],
+        ...defaults
+      });
+      auto.hooks.getRepository.tap('test', () => ({ token: '1234' }));
       await auto.loadConfig();
 
       const addToChangelog = jest.fn();
       auto.githubRelease!.addToChangelog = addToChangelog;
       auto.githubRelease!.generateReleaseNotes = jest.fn();
 
-      await auto.changelog();
+      await auto.changelog({ from: 'v1.0.0' });
       expect(addToChangelog).toHaveBeenCalled();
     });
   });

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,0 +1,11 @@
+import { AsyncSeriesBailHook, AsyncSeriesHook, SyncHook } from 'tapable';
+import { IAutoHooks } from '../main';
+
+export const makeHooks = (): IAutoHooks => ({
+  beforeRun: new SyncHook(['config']),
+  getAuthor: new AsyncSeriesBailHook([]),
+  getPreviousVersion: new AsyncSeriesBailHook(['prefixRelease']),
+  getRepository: new AsyncSeriesBailHook([]),
+  modifyChangelog: new AsyncSeriesBailHook(['commits', 'lineRender']),
+  publish: new AsyncSeriesHook(['version'])
+});

--- a/src/git.ts
+++ b/src/git.ts
@@ -394,38 +394,4 @@ export default class GitHub {
 
     return result;
   }
-
-  public async changedPackages(sha: string) {
-    const packages = new Set<string>();
-    const changedFiles = await execPromise('git', [
-      'show',
-      '--first-parent',
-      sha,
-      '--name-only',
-      '--pretty='
-    ]);
-
-    changedFiles.split('\n').forEach(filePath => {
-      const parts = filePath.split('/');
-
-      if (parts[0] !== 'packages' || parts.length < 3) {
-        return;
-      }
-
-      packages.add(
-        parts.length > 3 && parts[1][0] === '@'
-          ? `${parts[1]}/${parts[2]}`
-          : parts[1]
-      );
-    });
-
-    if (packages.size > 0) {
-      this.logger.veryVerbose.info(
-        `Got changed packages for ${sha}:\n`,
-        packages
-      );
-    }
-
-    return [...packages];
-  }
 }

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -90,11 +90,11 @@ export default class GitHubRelease {
 
   constructor(
     options: Partial<IGitHubOptions>,
+    hooks: IAutoHooks,
     releaseOptions: IGitHubReleaseOptions = {
       skipReleaseLabels: []
     },
-    logger: ILogger = dummyLog(),
-    hooks: IAutoHooks
+    logger: ILogger = dummyLog()
   ) {
     this.hooks = hooks;
     this.versionLabels = releaseOptions.versionLabels || defaultLabels;

--- a/src/main.ts
+++ b/src/main.ts
@@ -134,14 +134,14 @@ export class AutoRelease {
     const token = repository.token || (await getGitHubToken(config.githubApi));
     this.githubRelease = new GitHubRelease(
       { owner: config.owner, repo: config.repo, ...repository, token },
+      this.hooks,
       config,
-      this.logger,
-      this.hooks
+      this.logger
     );
   }
 
-  public async init({ onlyLabels }: IInitCommandOptions) {
-    await init(onlyLabels);
+  public async init(options: IInitCommandOptions = {}) {
+    await init(options.onlyLabels);
   }
 
   public async createLabels() {

--- a/src/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
+++ b/src/plugins/npm/__tests__/__snapshots__/monorepo-log.test.ts.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should create sections for packages 1`] = `
+"#### 💥  Breaking Change
+
+- woot [#12343](https://github.custom.com/pull/12343) (adam@dierkens.com)
+- \`@foobar/release\`, \`@foobar/party\`
+  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+  - [PLAYA-5052](jira.com/PLAYA-5052): Some Feature - Revert [#12345](https://github.custom.com/pull/12345) (adam@dierkens.com)
+
+#### 🏠  Internal
+
+- \`@foobar/release\`
+  - Another Feature [#1234](https://github.custom.com/pull/1234) (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;

--- a/src/plugins/npm/__tests__/git-changed-packages.test.ts
+++ b/src/plugins/npm/__tests__/git-changed-packages.test.ts
@@ -1,49 +1,32 @@
-import GitHub from '../git';
+import { changedPackages } from '../';
+import { dummyLog } from '../../../utils/logger';
 
 const exec = jest.fn();
 
 // @ts-ignore
-jest.mock('../utils/exec-promise.ts', () => (...args) => exec(...args));
+jest.mock('../../../utils/exec-promise.ts', () => (...args) => exec(...args));
 
 describe('changedPackages ', async () => {
   test('should return nothing without a package directory', async () => {
-    const gh = new GitHub({
-      owner: 'Adam Dierkens',
-      repo: 'test',
-      token: 'MyToken'
-    });
-
     exec.mockReturnValueOnce(`packages/README.md\npackage.json`);
 
-    expect(await gh.changedPackages('sha')).toEqual([]);
+    expect(await changedPackages('sha', dummyLog())).toEqual([]);
   });
 
   test('should match files in package directory', async () => {
-    const gh = new GitHub({
-      owner: 'Adam Dierkens',
-      repo: 'test',
-      token: 'MyToken'
-    });
-
     exec.mockReturnValueOnce(
       `packages/foo/README.md\npackages/bar/package.json`
     );
 
-    expect(await gh.changedPackages('sha')).toEqual(['foo', 'bar']);
+    expect(await changedPackages('sha', dummyLog())).toEqual(['foo', 'bar']);
   });
 
   test('should match files in package directory with @scope/ names', async () => {
-    const gh = new GitHub({
-      owner: 'Adam Dierkens',
-      repo: 'test',
-      token: 'MyToken'
-    });
-
     exec.mockReturnValueOnce(
       `packages/@scope/foo/README.md\npackages/@scope/bar/package.json`
     );
 
-    expect(await gh.changedPackages('sha')).toEqual([
+    expect(await changedPackages('sha', dummyLog())).toEqual([
       '@scope/foo',
       '@scope/bar'
     ]);

--- a/src/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/src/plugins/npm/__tests__/monorepo-log.test.ts
@@ -1,0 +1,71 @@
+import NpmPlugin from '..';
+import makeCommitFromMsg from '../../../__tests__/make-commit-from-msg';
+import { makeHooks } from '../../../__tests__/utils';
+import { defaultChangelogTitles, defaultLabels } from '../../../github-release';
+import generateReleaseNotes, { normalizeCommits } from '../../../log-parse';
+import { AutoRelease } from '../../../main';
+import { dummyLog } from '../../../utils/logger';
+
+const exec = jest.fn();
+
+// @ts-ignore
+jest.mock('../../../utils/exec-promise.ts', () => (...args) => exec(...args));
+jest.mock('fs', () => ({
+  // @ts-ignore
+  existsSync: jest.fn().mockReturnValue(true),
+  // @ts-ignore
+  readFile: jest.fn(),
+  // @ts-ignore
+  ReadStream: () => undefined,
+  // @ts-ignore
+  WriteStream: () => undefined,
+  // @ts-ignore
+  closeSync: () => undefined,
+  // @ts-ignore
+  writeFile: jest.fn()
+}));
+
+test('should create sections for packages', async () => {
+  const plugin = new NpmPlugin();
+  const hooks = makeHooks();
+  plugin.apply({ hooks, logger: dummyLog() } as AutoRelease);
+
+  exec.mockReturnValueOnce(
+    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
+  );
+  exec.mockReturnValueOnce(
+    'packages/@foobar/release/README.md\npackages/@foobar/party/package.json'
+  );
+  exec.mockReturnValueOnce('');
+  exec.mockReturnValueOnce('packages/@foobar/release/README.md');
+
+  expect(
+    await generateReleaseNotes(
+      normalizeCommits([
+        makeCommitFromMsg('[PLAYA-5052] - Some Feature (#12345)', {
+          labels: ['major']
+        }),
+        makeCommitFromMsg('[PLAYA-5052] - Some Feature - Revert (#12345)', {
+          labels: ['major']
+        }),
+        makeCommitFromMsg('woot (#12343)', {
+          labels: ['major']
+        }),
+        makeCommitFromMsg('Another Feature (#1234)', {
+          labels: ['internal']
+        }),
+        makeCommitFromMsg('Third')
+      ]),
+      dummyLog(),
+      {
+        owner: 'andrew',
+        repo: 'test',
+        jira: 'jira.com',
+        baseUrl: 'https://github.custom.com/',
+        changelogTitles: defaultChangelogTitles,
+        versionLabels: defaultLabels,
+        modifyChangelog: hooks.modifyChangelog
+      }
+    )
+  ).toMatchSnapshot();
+});

--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -31,7 +31,7 @@ async function greaterRelease(
     : publishedVersion;
 }
 
-async function changedPackages(sha: string, logger: ILogger) {
+export async function changedPackages(sha: string, logger: ILogger) {
   const packages = new Set<string>();
   const changedFiles = await execPromise('git', [
     'show',

--- a/src/plugins/npm/package-config.ts
+++ b/src/plugins/npm/package-config.ts
@@ -5,27 +5,17 @@ import { promisify } from 'util';
 export interface IRepoConfig {
   owner: string;
   repo: string;
-  version: string;
-}
-
-interface IPackageConfig {
-  version: string;
-  repository?:
-    | {
-        url: string;
-      }
-    | 'string';
 }
 
 const readFile = promisify(fs.readFile);
 
-const getPackageConfig = async (): Promise<IPackageConfig> => {
+const getPackageConfig = async (): Promise<IPackageJSON> => {
   const pkgConfig = await readFile('./package.json', 'utf-8');
   return JSON.parse(pkgConfig);
 };
 
 export default async function getConfigFromPackageJson(): Promise<IRepoConfig> {
-  const { repository, version } = await getPackageConfig();
+  const { repository } = await getPackageConfig();
 
   if (!repository) {
     throw new Error('Cannot read repo info from package.json');
@@ -44,7 +34,6 @@ export default async function getConfigFromPackageJson(): Promise<IRepoConfig> {
 
   return {
     repo: name,
-    owner,
-    version
+    owner
   };
 }


### PR DESCRIPTION
# What Changed

Moved all monorepo changelog functionality to the NPM plugin and made a new `modifyChangelog` hook.

# Why

closes #177

Todo:

- [x] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
