### PR TITLE
Pad color to be 6 digits long

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -23,6 +23,12 @@ export interface IGitHubOptions {
   token?: string;
 }
 
+export function getRandomColor() {
+  return Math.floor(Math.random() * 16777215)
+    .toString(16)
+    .padStart(6, '0');
+}
+
 class GitHubAPIError extends Error {
   constructor(api: string, args: object, origError: Error) {
     super(
@@ -265,7 +271,7 @@ export default class GitHub {
       name,
       owner: this.options.owner,
       repo: this.options.repo,
-      color: Math.floor(Math.random() * 16777215).toString(16),
+      color: getRandomColor(),
       description: defaultLabelsDescriptions.get(label)
     });
 


### PR DESCRIPTION
# What Changed

Padding the hex value of the random color generator to always be 6 digits.

Fixes #187 

# Why

The github API will fail if it's not. 

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
