### PR TITLE
Fix github repo lookup

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -433,5 +433,26 @@ describe('AutoRelease', () => {
       await auto.changelog({ from: 'v1.0.0' });
       expect(addToChangelog).toHaveBeenCalled();
     });
+
+    test('should skip getRepository hook if passed in via cli', async () => {
+      const auto = new AutoRelease({
+        command: 'pr',
+        repo: 'test',
+        owner: 'adierkens'
+      });
+
+      const hookFn = jest.fn();
+      auto.hooks.getRepository.tap('test', hookFn);
+      await auto.loadConfig();
+      await auto.pr({
+        url: 'foo.bar',
+        state: 'pending',
+        description: 'Waiting for stuffs',
+        context: 'tests',
+        dryRun: true
+      });
+
+      expect(hookFn).not.toBeCalled();
+    });
   });
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export class AutoRelease {
     this.loadPlugins(config);
     this.hooks.beforeRun.call(config);
 
-    const repository = await this.getRepo();
+    const repository = await this.getRepo(config);
     const token =
       repository && repository.token
         ? repository.token
@@ -521,13 +521,9 @@ If a command fails manually run:
     }
   }
 
-  private async getRepo() {
-    if (
-      this.githubRelease &&
-      this.githubRelease.releaseOptions.repo &&
-      this.githubRelease.releaseOptions.owner
-    ) {
-      return this.githubRelease.releaseOptions as IRepository;
+  private async getRepo(config: IGitHubReleaseOptions) {
+    if (config.owner && config.repo) {
+      return config as IRepository;
     }
 
     return this.hooks.getRepository.promise();


### PR DESCRIPTION
# What Changed

We call `this.getRepo()` before we create a `githubRelease` instance, which means the `if` check will never pass, even if you pass in the options for `repo` and `owner` via the cli. 

This uses the config that's generated (from the `.autorc` and cli args) to check for `repo` and `owner` before falling back to the hooks. 

# Why

I was getting 
```
{ Error: ENOENT: no such file or directory, open './package.json'
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: './package.json' }
```

on repos that had all the info they needed passed in via the cli, so it shouldn't be trying to open a file. 

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
