### PR TITLE
`auto label`: must sort PRs first because they can get merged out of order

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -140,7 +140,14 @@ describe('AutoRelease', () => {
       const getPullRequests = jest.fn();
       auto.githubRelease!.getPullRequests = getPullRequests;
       getPullRequests.mockReturnValueOnce([
-        { merged_at: true, labels: [{ name: 'foo' }, { name: 'bar' }] }
+        {
+          merged_at: '2019-01-08T03:45:33.000Z',
+          labels: [{ name: 'wubbalublub' }]
+        },
+        {
+          merged_at: '2019-01-10T03:45:33.000Z',
+          labels: [{ name: 'foo' }, { name: 'bar' }]
+        }
       ]);
       console.log = jest.fn();
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -178,7 +178,12 @@ export class AutoRelease {
       const pulls = await this.githubRelease.getPullRequests({
         state: 'closed'
       });
-      const lastMerged = pulls.find(pull => !!pull.merged_at);
+      const lastMerged = pulls
+        .sort(
+          (a, b) =>
+            new Date(b.merged_at).getTime() - new Date(a.merged_at).getTime()
+        )
+        .find(pull => !!pull.merged_at);
 
       if (lastMerged) {
         labels = lastMerged.labels.map(label => label.name);


### PR DESCRIPTION
# What Changed

see title

# Why

it was broke!

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
