### PR TITLE
release documentation only when files in `docs/` have changed

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -2,7 +2,7 @@ chmod +x ./dist/bin/auto.js
 
 export PATH=$(npm bin):$PATH
 
-SHOULD_PUBLISH=`./dist/bin/auto.js label | grep -F 'documentation'`
+SHOULD_PUBLISH=`git diff --name-only master | grep -F 'docs/'`
 
 if [ ! -z "$SHOULD_PUBLISH" ]; then
   ignite --publish


### PR DESCRIPTION
# What Changed

It wasn't the best experience having to add a documentation label to release the docs. Now it just happens!

# Why

automation is cool

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
