### PR TITLE
Only use PR commits to calculate SEMVER

### DIFF
--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -384,6 +384,7 @@ describe('GitHubRelease', () => {
     test('should not publish a release', async () => {
       const gh = new GitHubRelease(options);
       const commits = [
+        makeCommitFromMsg("I will be ignored since I'm not a PR"),
         makeCommitFromMsg('First (#1234)'),
         makeCommitFromMsg('Second (#1235)'),
         makeCommitFromMsg('Third (#1236)')

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -322,7 +322,18 @@ describe('generateReleaseNotes', () => {
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
       makeCommitFromMsg('First'),
-      makeCommitFromMsg('Some Feature (#1234)'),
+      {
+        hash: 'foo',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        authors: [
+          {
+            name: 'Adam Dierkens',
+            email: 'adam@dierkens.com'
+          }
+        ],
+        subject: 'Some Feature (#1234)'
+      },
       makeCommitFromMsg('Third')
     ]);
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -330,7 +330,11 @@ export default class GitHubRelease {
 
   public async getSemverBump(from: string, to = 'HEAD'): Promise<SEMVER> {
     const commits = await this.getCommits(from, to);
-    const labels = commits.map(commit => commit.labels);
+    const labels = commits
+      .map(commit => commit.labels)
+      .filter(
+        (list): list is string[] => Array.isArray(list) && list.length > 0
+      );
     const {
       onlyPublishWithReleaseLabel,
       skipReleaseLabels
@@ -384,9 +388,7 @@ export default class GitHubRelease {
 
     await Promise.all(
       eCommits.map(async commit => {
-        if (!commit.pullRequest) {
-          commit.labels = [];
-        } else {
+        if (commit.pullRequest) {
           commit.labels = await this.getLabels(
             parseInt(commit.pullRequest.number, 10)
           );

--- a/src/log-parse.ts
+++ b/src/log-parse.ts
@@ -30,7 +30,7 @@ export type IExtendedCommit = ICommit & {
   jira?: {
     number: string[];
   };
-  labels: string[];
+  labels?: string[];
   packages?: string[];
 };
 
@@ -161,7 +161,7 @@ export function normalizeCommits(commits: ICommit[]): IExtendedCommit[] {
 }
 
 const filterLabel = (commits: IExtendedCommit[], label: string) =>
-  commits.filter(commit => commit.labels.includes(label));
+  commits.filter(commit => commit.labels && commit.labels.includes(label));
 
 export default class LogParse {
   public readonly hooks: ILogParseHooks;
@@ -246,12 +246,14 @@ export default class LogParse {
   ): { [key: string]: IExtendedCommit[] } {
     let currentCommits = [...commits];
 
+    // Add 'patch' labels to PRs without any labels
     commits
       .filter(
         commit =>
-          (commit.pullRequest || commit.jira) && commit.labels.length === 0
+          (commit.pullRequest || commit.jira) &&
+          (!commit.labels || commit.labels.length === 0)
       )
-      .map(commit => commit.labels.push('patch'));
+      .forEach(commit => (commit.labels = ['patch']));
 
     return Object.assign(
       {},


### PR DESCRIPTION
# What Changed

only add label to commit if there is a pull request

# Why

If there happened to be extra commits since a PR was merged the `skip-release` and `release` labels would stop working since the only look at the latest commit.

closes #186

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
