### PR TITLE
Pushes to master create changelog entry

### DIFF
--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -65,7 +65,7 @@ Array [
       },
     ],
     "hash": "foo",
-    "labels": undefined,
+    "labels": Array [],
     "packages": undefined,
     "pullRequest": Object {
       "number": 123,
@@ -87,7 +87,7 @@ Array [
       },
     ],
     "hash": "foo",
-    "labels": undefined,
+    "labels": Array [],
     "packages": undefined,
     "pullRequest": Object {
       "number": 124,
@@ -145,7 +145,7 @@ Array [
       },
     ],
     "hash": "foo",
-    "labels": undefined,
+    "labels": Array [],
     "packages": undefined,
     "pullRequest": Object {
       "number": 123,

--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -27,7 +27,7 @@ exports[`GitHubRelease generateReleaseNotes should include PR-less commits 1`] =
 
 - First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### The following was pushed directly to master and treated as \`patch\`
 
 - I should be included  (adam@dierkens.com)
 
@@ -43,7 +43,7 @@ exports[`GitHubRelease generateReleaseNotes should match rebased commits to PRs 
 - Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
 - I was rebased [#123](https://github.com/web/site/pull/123) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### The following was pushed directly to master and treated as \`patch\`
 
 - I am a commit to master  (adam@dierkens.com)
 

--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -86,6 +86,21 @@ Array [
 ]
 `;
 
+exports[`GitHubRelease generateReleaseNotes should include PR-less commits 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+- I should be included  (adam@dierkens.com)
+
+#### Authors: 2
+
+- Adam Dierkens (adam@dierkens.com)
+- adam@dierkens.com"
+`;
+
 exports[`GitHubRelease getCommits should resolve authors with PR commits 1`] = `
 Array [
   Object {

--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -27,7 +27,7 @@ exports[`GitHubRelease generateReleaseNotes should include PR-less commits 1`] =
 
 - First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
 
-#### The following was pushed directly to master and treated as \`patch\`
+#### ⚠️  Pushed to master
 
 - I should be included  (adam@dierkens.com)
 
@@ -43,7 +43,7 @@ exports[`GitHubRelease generateReleaseNotes should match rebased commits to PRs 
 - Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
 - I was rebased [#123](https://github.com/web/site/pull/123) (adam@dierkens.com)
 
-#### The following was pushed directly to master and treated as \`patch\`
+#### ⚠️  Pushed to master
 
 - I am a commit to master  (adam@dierkens.com)
 

--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -22,6 +22,37 @@ exports[`GitHubRelease generateReleaseNotes should allow user to configure secti
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
+exports[`GitHubRelease generateReleaseNotes should include PR-less commits 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+- I should be included  (adam@dierkens.com)
+
+#### Authors: 2
+
+- Adam Dierkens (adam@dierkens.com)
+- adam@dierkens.com"
+`;
+
+exports[`GitHubRelease generateReleaseNotes should match rebased commits to PRs 1`] = `
+"#### 🚀  Enhancement
+
+- Feature [#124](https://github.com/web/site/pull/124) (adam@dierkens.com)
+- I was rebased [#123](https://github.com/web/site/pull/123) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+- I am a commit to master  (adam@dierkens.com)
+
+#### Authors: 2
+
+- Adam Dierkens (adam@dierkens.com)
+- adam@dierkens.com"
+`;
+
 exports[`GitHubRelease getCommits should ignore rebased commits if no last release 1`] = `
 Array [
   Object {
@@ -84,21 +115,6 @@ Array [
     "subject": "I was rebased",
   },
 ]
-`;
-
-exports[`GitHubRelease generateReleaseNotes should include PR-less commits 1`] = `
-"#### 🚀  Enhancement
-
-- First Feature [#1235](https://github.com/web/site/pull/1235) (adam@dierkens.com)
-
-#### 🐛  Bug Fix
-
-- I should be included  (adam@dierkens.com)
-
-#### Authors: 2
-
-- Adam Dierkens (adam@dierkens.com)
-- adam@dierkens.com"
 `;
 
 exports[`GitHubRelease getCommits should resolve authors with PR commits 1`] = `

--- a/src/__tests__/__snapshots__/log-parse.test.ts.snap
+++ b/src/__tests__/__snapshots__/log-parse.test.ts.snap
@@ -84,6 +84,20 @@ exports[`generateReleaseNotes should omit authors with invalid email addresses 1
 - Some Feature [#1234](https://github.custom.com/foobar/auto-release/pull/1234)"
 `;
 
+exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
+"#### 🚀  Enhancement
+
+- First Feature [#1235](https://github.custom.com/foobar/auto-release/pull/1235) (adam@dierkens.com)
+
+#### 🐛  Bug Fix
+
+- I should be included  (adam@dierkens.com)
+
+#### Authors: 1
+
+- Adam Dierkens (adam@dierkens.com)"
+`;
+
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `
 "#### 🐛  Bug Fix
 

--- a/src/__tests__/__snapshots__/log-parse.test.ts.snap
+++ b/src/__tests__/__snapshots__/log-parse.test.ts.snap
@@ -78,24 +78,24 @@ exports[`generateReleaseNotes should create note for jira commits without labels
 - Adam Dierkens (adam@dierkens.com)"
 `;
 
-exports[`generateReleaseNotes should omit authors with invalid email addresses 1`] = `
-"#### 🚀  Enhancement
-
-- Some Feature [#1234](https://github.custom.com/foobar/auto-release/pull/1234)"
-`;
-
 exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 "#### 🚀  Enhancement
 
 - First Feature [#1235](https://github.custom.com/foobar/auto-release/pull/1235) (adam@dierkens.com)
 
-#### 🐛  Bug Fix
+#### The following was pushed directly to master and treated as \`patch\`
 
-- I should be included  (adam@dierkens.com)
+- I was a push to master  (adam@dierkens.com)
 
 #### Authors: 1
 
 - Adam Dierkens (adam@dierkens.com)"
+`;
+
+exports[`generateReleaseNotes should omit authors with invalid email addresses 1`] = `
+"#### 🚀  Enhancement
+
+- Some Feature [#1234](https://github.custom.com/foobar/auto-release/pull/1234)"
 `;
 
 exports[`generateReleaseNotes should use only email if author name doesn't exist 1`] = `

--- a/src/__tests__/__snapshots__/log-parse.test.ts.snap
+++ b/src/__tests__/__snapshots__/log-parse.test.ts.snap
@@ -83,7 +83,7 @@ exports[`generateReleaseNotes should include PR-less commits as patches 1`] = `
 
 - First Feature [#1235](https://github.custom.com/foobar/auto-release/pull/1235) (adam@dierkens.com)
 
-#### The following was pushed directly to master and treated as \`patch\`
+#### ⚠️  Pushed to master
 
 - I was a push to master  (adam@dierkens.com)
 

--- a/src/__tests__/__snapshots__/main.test.ts.snap
+++ b/src/__tests__/__snapshots__/main.test.ts.snap
@@ -13,6 +13,7 @@ exports[`AutoRelease createLabels should create the labels 1`] = `
         "prerelease" => "prerelease",
         "internal" => "internal",
         "documentation" => "documentation",
+        "push-to-master" => "push-to-master",
       },
     ],
   ],

--- a/src/__tests__/__snapshots__/main.test.ts.snap
+++ b/src/__tests__/__snapshots__/main.test.ts.snap
@@ -13,7 +13,6 @@ exports[`AutoRelease createLabels should create the labels 1`] = `
         "prerelease" => "prerelease",
         "internal" => "internal",
         "documentation" => "documentation",
-        "push-to-master" => "push-to-master",
       },
     ],
   ],

--- a/src/__tests__/github-release.test.ts
+++ b/src/__tests__/github-release.test.ts
@@ -362,6 +362,59 @@ describe('GitHubRelease', () => {
       expect(await gh.generateReleaseNotes('1234', '123')).toBe('');
     });
 
+    test('should include PR-less commits', async () => {
+      const gh = new GitHubRelease(options);
+
+      const commits = [
+        {
+          hash: '1',
+          authorName: 'Adam Dierkens',
+          authorEmail: 'adam@dierkens.com',
+          authors: [
+            {
+              name: 'Adam Dierkens',
+              email: 'adam@dierkens.com'
+            }
+          ],
+          subject: 'I should be included'
+        },
+        {
+          hash: '2',
+          authorName: 'Adam Dierkens',
+          authorEmail: 'adam@dierkens.com',
+          authors: [
+            {
+              name: 'Adam Dierkens',
+              email: 'adam@dierkens.com'
+            }
+          ],
+          subject: 'First Feature',
+          pullRequest: {
+            number: '1235'
+          }
+        },
+        {
+          hash: '3',
+          authorName: 'Adam Dierkens',
+          authorEmail: 'adam@dierkens.com',
+          authors: [
+            {
+              name: 'Adam Dierkens',
+              email: 'adam@dierkens.com'
+            }
+          ],
+          subject: 'Random Commit for pr 1235'
+        }
+      ];
+
+      getGitLog.mockReturnValueOnce(commits);
+      getCommitsForPR.mockReturnValueOnce(undefined);
+      getLabels.mockReturnValueOnce(['minor']);
+      getCommitsForPR.mockReturnValueOnce([{ sha: '3' }]);
+
+      expect(await gh.generateReleaseNotes('1234', '123')).toMatchSnapshot();
+    });
+
     test('should allow user to configure section headings', async () => {
       const gh = new GitHubRelease(options);
 

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -254,9 +254,7 @@ describe('Hooks', () => {
   test('title', async () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('Some Feature (#1234)'),
-      makeCommitFromMsg('Third')
+      makeCommitFromMsg('Some Feature (#1234)')
     ]);
 
     logParse.hooks.renderChangelogTitle.tap(
@@ -271,9 +269,7 @@ describe('Hooks', () => {
   test('author', async () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('Some Feature (#1234)'),
-      makeCommitFromMsg('Third')
+      makeCommitFromMsg('Some Feature (#1234)')
     ]);
 
     logParse.hooks.renderChangelogAuthor.tap(
@@ -292,26 +288,11 @@ describe('Hooks', () => {
 });
 
 describe('generateReleaseNotes', () => {
-  test('should not create notes for normal commits', async () => {
-    const logParse = new LogParse(dummyLog(), testOptions());
-    logParse.loadDefaultHooks();
-
-    expect(
-      await logParse.generateReleaseNotes([
-        makeCommitFromMsg('First'),
-        makeCommitFromMsg('Second'),
-        makeCommitFromMsg('Third')
-      ])
-    ).toBe('');
-  });
-
   test('should create note for PR commits', async () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('Some Feature (#1234)', { labels: ['minor'] }),
-      makeCommitFromMsg('Third')
+      makeCommitFromMsg('Some Feature (#1234)', { labels: ['minor'] })
     ]);
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
@@ -332,9 +313,7 @@ describe('generateReleaseNotes', () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('Some Feature (#1234)'),
-      makeCommitFromMsg('Third')
+      makeCommitFromMsg('Some Feature (#1234)')
     ]);
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
@@ -344,9 +323,7 @@ describe('generateReleaseNotes', () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
-      makeCommitFromMsg('[PLAYA-5052] - Fix P0'),
-      makeCommitFromMsg('Third')
+      makeCommitFromMsg('[PLAYA-5052] - Fix P0')
     ]);
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
@@ -356,15 +333,13 @@ describe('generateReleaseNotes', () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
-      makeCommitFromMsg('First'),
       makeCommitFromMsg('Some Feature (#1234)', {
         labels: ['minor'],
         username: 'adam'
-      }),
-      makeCommitFromMsg('Third')
+      })
     ]);
 
-    normalized[1].authors[0].username = 'adam';
+    normalized[0].authors[0].username = 'adam';
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
   });
@@ -378,8 +353,7 @@ describe('generateReleaseNotes', () => {
         packages: []
       }),
       makeCommitFromMsg('Some Feature (#1234)', { labels: ['internal'] }),
-      makeCommitFromMsg('Third', { labels: ['patch'] }),
-      makeCommitFromMsg('Fourth')
+      makeCommitFromMsg('Third', { labels: ['patch'] })
     ]);
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
@@ -390,8 +364,7 @@ describe('generateReleaseNotes', () => {
     logParse.loadDefaultHooks();
     const normalized = normalizeCommits([
       makeCommitFromMsg('Some Feature (#1234)'),
-      makeCommitFromMsg('Third', { labels: ['patch'] }),
-      makeCommitFromMsg('Fourth')
+      makeCommitFromMsg('Third', { labels: ['patch'] })
     ]);
 
     expect(await logParse.generateReleaseNotes(normalized)).toMatchSnapshot();
@@ -415,5 +388,28 @@ describe('generateReleaseNotes', () => {
     ]);
 
     expect(await logParse.generateReleaseNotes(commits)).toMatchSnapshot();
+  });
+
+  test.only('should include PR-less commits as patches', async () => {
+    const logParse = new LogParse(dummyLog(), testOptions());
+    logParse.loadDefaultHooks();
+
+    const commits = normalizeCommits([
+      {
+        hash: '1',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'I should be included'
+      },
+      {
+        hash: '2',
+        authorName: 'Adam Dierkens',
+        authorEmail: 'adam@dierkens.com',
+        subject: 'First Feature (#1235)',
+        labels: ['minor']
+      }
+    ]);
+
+    expect(await logParse.generateReleaseNotes(commits)).toBe('');
   });
 });

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -390,7 +390,7 @@ describe('generateReleaseNotes', () => {
     expect(await logParse.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 
-  test.only('should include PR-less commits as patches', async () => {
+  test('should include PR-less commits as patches', async () => {
     const logParse = new LogParse(dummyLog(), testOptions());
     logParse.loadDefaultHooks();
 
@@ -410,6 +410,6 @@ describe('generateReleaseNotes', () => {
       }
     ]);
 
-    expect(await logParse.generateReleaseNotes(commits)).toBe('');
+    expect(await logParse.generateReleaseNotes(commits)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -394,7 +394,7 @@ describe('generateReleaseNotes', () => {
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
         subject: 'I was a push to master',
-        labels: ['push-to-master']
+        labels: ['pushToMaster']
       },
       {
         hash: '2',

--- a/src/__tests__/log-parse.test.ts
+++ b/src/__tests__/log-parse.test.ts
@@ -1,4 +1,4 @@
-import { defaultLabels } from '../github-release';
+import { defaultChangelogTitles, defaultLabels } from '../github-release';
 import LogParse, {
   filterServiceAccounts,
   IGenerateReleaseNotesOptions,
@@ -241,13 +241,7 @@ const testOptions = (): IGenerateReleaseNotesOptions => ({
   baseUrl: 'https://github.custom.com/foobar/auto-release',
   jira: 'https://jira.custom.com/browse',
   versionLabels: defaultLabels,
-  changelogTitles: {
-    major: '💥  Breaking Change',
-    minor: '🚀  Enhancement',
-    patch: '🐛  Bug Fix',
-    internal: '🏠  Internal',
-    documentation: '📝  Documentation'
-  }
+  changelogTitles: defaultChangelogTitles
 });
 
 describe('Hooks', () => {
@@ -399,7 +393,8 @@ describe('generateReleaseNotes', () => {
         hash: '1',
         authorName: 'Adam Dierkens',
         authorEmail: 'adam@dierkens.com',
-        subject: 'I should be included'
+        subject: 'I was a push to master',
+        labels: ['push-to-master']
       },
       {
         hash: '2',

--- a/src/git.ts
+++ b/src/git.ts
@@ -86,6 +86,7 @@ export default class GitHub {
     return Promise.resolve();
   }
 
+  @Memoize()
   public async getLatestReleaseInfo() {
     const latestRelease = await this.ghub.repos.getLatestRelease({
       owner: this.options.owner,
@@ -95,6 +96,7 @@ export default class GitHub {
     return latestRelease.data;
   }
 
+  @Memoize()
   public async getLatestRelease(): Promise<string> {
     await this.authenticate();
 
@@ -133,6 +135,7 @@ export default class GitHub {
     return result;
   }
 
+  @Memoize()
   public async getLabels(prNumber: number) {
     this.logger.verbose.info(`Getting labels for PR: ${prNumber}`);
 
@@ -224,6 +227,7 @@ export default class GitHub {
     })).data;
   }
 
+  @Memoize()
   public async getPullRequest(pr: number) {
     this.logger.verbose.info(`Getting Pull Request: ${pr}`);
 
@@ -299,6 +303,7 @@ export default class GitHub {
     return result;
   }
 
+  @Memoize()
   public async getProject() {
     this.logger.verbose.info('Getting project from GitHub');
 
@@ -332,6 +337,7 @@ export default class GitHub {
     return result;
   }
 
+  @Memoize()
   public async getCommitsForPR(pr: number) {
     this.logger.verbose.info(`Getting commits for PR #${pr}`);
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -52,9 +52,7 @@ export const defaultChangelogTitles = {
   minor: '🚀  Enhancement',
   patch: '🐛  Bug Fix',
   internal: '🏠  Internal',
-  documentation: '📝  Documentation',
-  'push-to-master':
-    '⚠️  Pushed to master'
+  documentation: '📝  Documentation'
 };
 
 export const defaultLabelsDescriptions = new Map<string, string>();
@@ -161,7 +159,7 @@ export default class GitHubRelease {
           return commit;
         }
 
-        commit.labels = ['push-to-master'];
+        commit.labels = ['pushToMaster'];
         return commit;
       });
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -135,7 +135,7 @@ export default class GitHubRelease {
     to = 'HEAD'
   ): Promise<string> {
     const allCommits = await this.getCommits(from, to);
-    const allPrHashes = await allCommits
+    const allPrCommitHashes = await allCommits
       .filter(commit => commit.pullRequest)
       .reduce(
         async (lastResult, commit) => {
@@ -150,7 +150,7 @@ export default class GitHubRelease {
       );
     const commits = allCommits.filter(
       commit =>
-        !allPrHashes.includes(commit.hash) &&
+        !allPrCommitHashes.includes(commit.hash) &&
         !commit.subject.includes('[skip ci]')
     );
 
@@ -407,7 +407,8 @@ export default class GitHubRelease {
         if (!commit.pullRequest) {
           commit.labels = [];
         } else {
-          commit.labels = await this.getLabels(commit.pullRequest.number);
+          commit.labels =
+            (await this.getLabels(commit.pullRequest.number)) || [];
         }
       })
     );

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -54,7 +54,7 @@ export const defaultChangelogTitles = {
   internal: '🏠  Internal',
   documentation: '📝  Documentation',
   'push-to-master':
-    'The following was pushed directly to master and treated as `patch`'
+    '⚠️  Pushed to master'
 };
 
 export const defaultLabelsDescriptions = new Map<string, string>();

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -52,7 +52,9 @@ export const defaultChangelogTitles = {
   minor: '🚀  Enhancement',
   patch: '🐛  Bug Fix',
   internal: '🏠  Internal',
-  documentation: '📝  Documentation'
+  documentation: '📝  Documentation',
+  'push-to-master':
+    'The following was pushed directly to master and treated as `patch`'
 };
 
 export const defaultLabelsDescriptions = new Map<string, string>();
@@ -148,11 +150,20 @@ export default class GitHubRelease {
         },
         Promise.resolve([]) as Promise<string[]>
       );
-    const commits = allCommits.filter(
-      commit =>
-        !allPrCommitHashes.includes(commit.hash) &&
-        !commit.subject.includes('[skip ci]')
-    );
+    const commits = allCommits
+      .filter(
+        commit =>
+          !allPrCommitHashes.includes(commit.hash) &&
+          !commit.subject.includes('[skip ci]')
+      )
+      .map(commit => {
+        if (commit.pullRequest) {
+          return commit;
+        }
+
+        commit.labels = ['push-to-master'];
+        return commit;
+      });
 
     const project = await this.github.getProject();
     const logParser = new LogParse(this.logger, {

--- a/src/log-parse.ts
+++ b/src/log-parse.ts
@@ -197,6 +197,7 @@ export default class LogParse {
     );
   }
 
+  // Every Commit will either be a PR, jira story, or push to master (patch)
   public async generateReleaseNotes(
     commits: IExtendedCommit[]
   ): Promise<string> {
@@ -241,7 +242,7 @@ export default class LogParse {
   }
 
   /**
-   * Split commits into changelogTitle sections
+   * Split commits into changelogTitle sections.
    */
   private splitCommits(
     commits: IExtendedCommit[]
@@ -249,10 +250,7 @@ export default class LogParse {
     let currentCommits = [...commits];
 
     commits
-      .filter(
-        commit =>
-          (commit.pullRequest || commit.jira) && commit.labels.length === 0
-      )
+      .filter(commit => commit.labels.length === 0)
       .map(commit => commit.labels.push('patch'));
 
     return Object.assign(

--- a/src/log-parse.ts
+++ b/src/log-parse.ts
@@ -175,6 +175,7 @@ export default class LogParse {
     this.logger = logger;
     this.options = options;
     this.hooks = makeLogHooks();
+    this.options.changelogTitles.pushToMaster = '⚠️  Pushed to master';
   }
 
   public loadDefaultHooks() {

--- a/src/plugins/npm/__tests__/monorepo-log.test.ts
+++ b/src/plugins/npm/__tests__/monorepo-log.test.ts
@@ -46,8 +46,7 @@ const commits = normalizeCommits([
   }),
   makeCommitFromMsg('Another Feature (#1234)', {
     labels: ['internal']
-  }),
-  makeCommitFromMsg('Third')
+  })
 ]);
 
 test('should create sections for packages', async () => {


### PR DESCRIPTION

# What Changed

pushes to master are included in changelog, filters out commits associated with a PR.

# Why

closes #202

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
