### PR TITLE
NPM Plugin: if there is no published version default to package.json version

### DIFF
--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -22,13 +22,17 @@ async function greaterRelease(
   name: any,
   packageVersion: string
 ) {
-  const publishedVersion = prefixRelease(
-    await execPromise('npm', ['view', name, 'version'])
-  );
+  try {
+    const publishedVersion = prefixRelease(
+      await execPromise('npm', ['view', name, 'version'])
+    );
 
-  return gt(packageVersion, publishedVersion)
-    ? packageVersion
-    : publishedVersion;
+    return gt(packageVersion, publishedVersion)
+      ? packageVersion
+      : publishedVersion;
+  } catch (error) {
+    return packageVersion;
+  }
 }
 
 export async function changedPackages(sha: string, logger: ILogger) {


### PR DESCRIPTION
# What Changed

see title

# Why

on previously unpublished packages `shipit` was failing

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
