### PR TITLE
 When there are no releases use first commit date for rebased PRs

### DIFF
--- a/src/__tests__/__snapshots__/github-release.test.ts.snap
+++ b/src/__tests__/__snapshots__/github-release.test.ts.snap
@@ -86,6 +86,48 @@ Array [
 ]
 `;
 
+exports[`GitHubRelease getCommits should match rebased commits to PRs with first commit 1`] = `
+Array [
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "hash": "foo",
+    "labels": undefined,
+    "packages": undefined,
+    "pullRequest": Object {
+      "number": 124,
+    },
+    "subject": "Feature",
+  },
+  Object {
+    "authorEmail": "adam@dierkens.com",
+    "authorName": "Adam Dierkens",
+    "authors": Array [
+      Object {
+        "email": "adam@dierkens.com",
+        "name": "Adam Dierkens",
+      },
+    ],
+    "hash": "1a2b",
+    "labels": Array [
+      "skip-release",
+      "minor",
+    ],
+    "packages": undefined,
+    "pullRequest": Object {
+      "number": 123,
+    },
+    "subject": "I was rebased",
+  },
+]
+`;
+
 exports[`GitHubRelease getCommits should resolve authors with PR commits 1`] = `
 Array [
   Object {

--- a/src/__tests__/git.test.ts
+++ b/src/__tests__/git.test.ts
@@ -148,6 +148,14 @@ describe('github', () => {
     );
   });
 
+  test('getCommitDate ', async () => {
+    const gh = new GitHub(options);
+
+    expect(
+      await gh.getCommitDate('0b2af75d8b55c8869cda93d0e5589ad9f2677e18')
+    ).toBe('2018-12-03T15:19:38-0800');
+  });
+
   test('getSha', async () => {
     const gh = new GitHub(options);
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -120,6 +120,13 @@ export default class GitHub {
     }
   }
 
+  public async getCommitDate(sha: string): Promise<string> {
+    const date = await execPromise('git', ['show', '-s', '--format=%ci', sha]);
+    const [day, time, timezone] = date.split(' ');
+
+    return `${day}T${time}${timezone}`;
+  }
+
   public async getFirstCommit(): Promise<string> {
     const list = await execPromise('git', ['rev-list', 'HEAD']);
     return list.split('\n').pop() as string;

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -397,7 +397,16 @@ export default class GitHubRelease {
   }
 
   private async getPRForRebasedCommits(commits: IExtendedCommit[]) {
-    const lastRelease = await this.github.getLatestReleaseInfo();
+    let lastRelease: { published_at: string };
+
+    try {
+      lastRelease = await this.github.getLatestReleaseInfo();
+    } catch (error) {
+      const firstCommit = await this.github.getFirstCommit();
+      lastRelease = {
+        published_at: await this.github.getCommitDate(firstCommit)
+      };
+    }
 
     if (!lastRelease || !lastRelease.published_at) {
       return commits;


### PR DESCRIPTION
# What Changed

see title

# Why

`auto version` was broken on fresh repo

Todo:

- [x] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
