### PR TITLE
Proper Error Catching

### DIFF
--- a/src/plugins/npm/index.ts
+++ b/src/plugins/npm/index.ts
@@ -19,7 +19,7 @@ function isMonorepo() {
 
 async function getPublishedVersion(name: string) {
   try {
-    return execPromise('npm', ['view', name, 'version']);
+    return await execPromise('npm', ['view', name, 'version']);
   } catch (error) {
     return null;
   }


### PR DESCRIPTION
# What Changed

you must use `return await` to actually catch the error in this function

# Why

Another fresh install bug.

Todo:

- [ ] Add tests
- [ ] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
