### PR TITLE
Add dry-run flag for the rest of the commands

### DIFF
--- a/docs/pages/auto-changelog.md
+++ b/docs/pages/auto-changelog.md
@@ -11,7 +11,7 @@ Prepend release notes to `CHANGELOG.md`, create one if it doesn't exist, and com
 
 Options
 
-  -d, --dry-run          Dont actually commit status. Just print the request body
+  -d, --dry-run          Report what command will do but do not actually do anything
   --no-version-prefix    Use the version as the tag without the 'v' prefix
   --jira string          Jira base URL
   --from string          Tag to start changelog generation on. Defaults to latest tag.

--- a/docs/pages/auto-comment.md
+++ b/docs/pages/auto-comment.md
@@ -16,6 +16,7 @@ Options
   --pr number [required]            The pull request number you want the labels of
   --context string                  A string label to differentiate this status from others
   -m, --message string [required]   Message to post to comment
+  -d, --dry-run                     Report what command will do but do not actually do anything
 
 Global Options
 

--- a/docs/pages/auto-init.md
+++ b/docs/pages/auto-init.md
@@ -12,7 +12,8 @@ $ auto init --help
 Options
 
   --only-labels    Only run init for the labels. As most other options are for advanced users
-  -d, --dry-run    Dont actually commit status. Just print the request body
+  -d, --dry-run    Report what command will do but do not actually do anything
+
 Examples
 
   $ auto init
@@ -24,6 +25,10 @@ Create your project's labels on github.
 
 ```sh
 $ auto create-labels --help
+
+Options
+
+  -d, --dry-run    Report what command will do but do not actually do anything
 
 Global Options
 

--- a/docs/pages/auto-init.md
+++ b/docs/pages/auto-init.md
@@ -12,7 +12,7 @@ $ auto init --help
 Options
 
   --only-labels    Only run init for the labels. As most other options are for advanced users
-
+  -d, --dry-run    Dont actually commit status. Just print the request body
 Examples
 
   $ auto init

--- a/docs/pages/auto-pr-check.md
+++ b/docs/pages/auto-pr-check.md
@@ -18,6 +18,7 @@ Options
   --only-publish-with-release-label    Only bump version if 'release' label is on pull request
   --context string                     A string label to differentiate this status from others
   --skip-release-labels string[]       Labels that will not create a release. Defaults to just 'skip-release'
+  -d, --dry-run                        Report what command will do but do not actually do anything
 
 Global Options
 

--- a/docs/pages/auto-pr.md
+++ b/docs/pages/auto-pr.md
@@ -15,6 +15,7 @@ Options
   --state string [required]         State of the PR. ['pending', 'success', 'error', 'failure']
   --description string [required]   A description of the status
   --context string [required]       A string label to differentiate this status from others
+  -d, --dry-run                     Report what command will do but do not actually do anything
 
 Global Options
 

--- a/docs/pages/auto-release.md
+++ b/docs/pages/auto-release.md
@@ -28,7 +28,7 @@ You will need to push the tags to github first:
 
 Options
 
-  -d, --dry-run          Dont actually commit status. Just print the request body
+  -d, --dry-run          Report what command will do but do not actually do anything
   --no-version-prefix    Use the version as the tag without the 'v' prefix
   --jira string          Jira base URL
   --use-version string   Version number to publish as. Defaults to reading from the package definition for the platform.

--- a/docs/pages/auto-shipit.md
+++ b/docs/pages/auto-shipit.md
@@ -12,6 +12,10 @@ auto shipit
 
 $ auto shipit --help
 
+Options
+
+  -d, --dry-run    Report what command will do but do not actually do anything
+
 Global Options
 
   -h, --help            Display the help output for the command

--- a/src/__tests__/__snapshots__/main.test.ts.snap
+++ b/src/__tests__/__snapshots__/main.test.ts.snap
@@ -14,6 +14,7 @@ exports[`AutoRelease createLabels should create the labels 1`] = `
         "internal" => "internal",
         "documentation" => "documentation",
       },
+      Object {},
     ],
   ],
   "results": Array [

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -368,6 +368,7 @@ const commands: ICommand[] = [
       pr,
       context,
       { ...message, description: 'Message to post to comment' },
+      dryRun,
       ...defaultOptions
     ],
     examples: [
@@ -636,6 +637,7 @@ export interface ICommentCommandOptions {
   pr: number;
   message: string;
   context?: string;
+  dryRun?: boolean;
 }
 
 type GlobalFlags = {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -380,7 +380,7 @@ const commands: ICommand[] = [
     name: 'shipit',
     summary: 'Run the full auto-release project. Detects if in a lerna project',
     examples: ['{green $} auto shipit'],
-    options: defaultOptions
+    options: [...defaultOptions, dryRun]
   }
 ];
 
@@ -641,6 +641,10 @@ export interface ICommentCommandOptions {
   dryRun?: boolean;
 }
 
+export interface IShipItCommandOptions {
+  dryRun?: boolean;
+}
+
 type GlobalFlags = {
   command: string;
   githubApi?: string;
@@ -651,19 +655,23 @@ type GlobalFlags = {
 export type ArgsType = GlobalFlags &
   (
     | IInitCommandOptions
+    | ICreateLabelsCommandOptions
     | ILabelCommandOptions
     | IPRCheckCommandOptions
     | IPRCommandOptions
     | ICommentCommandOptions
     | IReleaseOptions
-    | IVersionCommandOptions);
+    | IVersionCommandOptions
+    | IShipItCommandOptions);
 
 type Flags =
   | keyof GlobalFlags
   | keyof IInitCommandOptions
+  | keyof ICreateLabelsCommandOptions
   | keyof ILabelCommandOptions
   | keyof IPRCheckCommandOptions
   | keyof IPRCommandOptions
   | keyof ICommentCommandOptions
   | keyof IReleaseOptions
-  | keyof IVersionCommandOptions;
+  | keyof IVersionCommandOptions
+  | keyof IShipItCommandOptions;

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -191,7 +191,8 @@ const commands: ICommand[] = [
         group: 'main',
         description:
           'Only run init for the labels. As most other options are for advanced users'
-      }
+      },
+      dryRun
     ]
   },
   {
@@ -580,6 +581,7 @@ interface ILogArgs {
 
 export interface IInitCommandOptions {
   onlyLabels?: boolean;
+  dryRun?: boolean;
 }
 
 export interface ILabelCommandOptions {

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -262,6 +262,7 @@ const commands: ICommand[] = [
         group: 'main',
         description: 'A string label to differentiate this status from others'
       },
+      dryRun,
       ...defaultOptions
     ],
     examples: [

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -107,7 +107,7 @@ const dryRun: commandLineUsage.OptionDefinition = {
   name: 'dry-run',
   alias: 'd',
   type: Boolean,
-  description: 'Dont actually commit status. Just print the request body',
+  description: 'Report what command will do but do not actually do anything',
   group: 'main'
 };
 
@@ -199,7 +199,7 @@ const commands: ICommand[] = [
     name: 'create-labels',
     summary: "Create your project's labels on github.",
     examples: ['{green $} auto create-labels'],
-    options: defaultOptions
+    options: [...defaultOptions, dryRun]
   },
   {
     name: 'label',
@@ -581,6 +581,10 @@ interface ILogArgs {
 
 export interface IInitCommandOptions {
   onlyLabels?: boolean;
+  dryRun?: boolean;
+}
+
+export interface ICreateLabelsCommandOptions {
   dryRun?: boolean;
 }
 

--- a/src/github-release.ts
+++ b/src/github-release.ts
@@ -329,7 +329,7 @@ export default class GitHubRelease {
 
   public async addLabelsToProject(
     labels: Map<string, string>,
-    options: ICreateLabelsCommandOptions
+    options: ICreateLabelsCommandOptions = {}
   ) {
     const oldLabels = await this.github.getProjectLabels();
     const labelsToCreate = [...labels.entries()].filter(

--- a/src/init.ts
+++ b/src/init.ts
@@ -5,7 +5,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { promisify } from 'util';
 
+import { IInitCommandOptions } from './cli/args';
 import { defaultChangelogTitles } from './github-release';
+import { ILogger } from './utils/logger';
 
 const writeFile = promisify(fs.writeFile);
 const isObject = (value: any) => typeof value === 'object' && value !== null;
@@ -189,7 +191,10 @@ documentation: #{documentation}
   return changelogTitles;
 }
 
-export default async function init(onlyLabels?: boolean) {
+export default async function init(
+  { onlyLabels, dryRun }: IInitCommandOptions,
+  logger: ILogger
+) {
   const flags = onlyLabels ? {} : await getFlags();
   const labels = await getLabels();
   const changelogTitles = await getChangelogTitles();
@@ -217,8 +222,11 @@ export default async function init(onlyLabels?: boolean) {
     return;
   }
 
-  await writeFile(
-    path.join(process.cwd(), '.autorc'),
-    JSON.stringify(autoRc, null, 2)
-  );
+  const jsonString = JSON.stringify(autoRc, null, 2);
+
+  if (dryRun) {
+    logger.log.note(`Initialization options would be:\n${jsonString}`);
+  } else {
+    await writeFile(path.join(process.cwd(), '.autorc'), jsonString);
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,7 +143,7 @@ export class AutoRelease {
   }
 
   public async init(options: IInitCommandOptions = {}) {
-    await init(options.onlyLabels);
+    await init(options, this.logger);
   }
 
   public async createLabels() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   ArgsType,
   IChangelogOptions,
   ICommentCommandOptions,
+  ICreateLabelsCommandOptions,
   IInitCommandOptions,
   ILabelCommandOptions,
   IPRCheckCommandOptions,
@@ -146,7 +147,7 @@ export class AutoRelease {
     await init(options, this.logger);
   }
 
-  public async createLabels() {
+  public async createLabels(options: ICreateLabelsCommandOptions = {}) {
     if (!this.githubRelease) {
       throw this.createErrorMessage();
     }
@@ -162,7 +163,8 @@ export class AutoRelease {
             )
           ].map((label): [string, string] => [label, label])
         )
-      ])
+      ]),
+      options
     );
   }
 
@@ -559,7 +561,7 @@ export async function run(args: ArgsType) {
       break;
     case 'create-labels':
       await auto.loadConfig();
-      await auto.createLabels();
+      await auto.createLabels(args as ICreateLabelsCommandOptions);
       break;
     case 'label':
       await auto.loadConfig();

--- a/src/main.ts
+++ b/src/main.ts
@@ -319,14 +319,26 @@ export class AutoRelease {
     this.logger.verbose.success('Finished `pr-check` command');
   }
 
-  public async comment({ message, pr, context }: ICommentCommandOptions) {
+  public async comment({
+    message,
+    pr,
+    context = 'default',
+    dryRun
+  }: ICommentCommandOptions) {
     if (!this.githubRelease) {
       throw this.createErrorMessage();
     }
 
     this.logger.verbose.info("Using command: 'comment'");
-    await this.githubRelease.createComment(message, pr, context);
-    this.logger.log.success(`Commented on PR #${pr}`);
+
+    if (dryRun) {
+      this.logger.log.info(
+        `Would have commented on ${pr} under "${context}" context:\n\n${message}`
+      );
+    } else {
+      await this.githubRelease.createComment(message, pr, context);
+      this.logger.log.success(`Commented on PR #${pr}`);
+    }
   }
 
   public async version() {


### PR DESCRIPTION
# What Changed

dry run for 

- init
- create-labels
- comment
- pr
- pr-check
- shipit

# Why

closes #220 

Todo:

- [ ] Add tests
- [x] Add docs
- [ ] Add yourself to contributors (run `yarn contributors:add`)
